### PR TITLE
Subscription Group Signup docs

### DIFF
--- a/reference/Chargify-API.v1.yaml
+++ b/reference/Chargify-API.v1.yaml
@@ -13734,8 +13734,8 @@ paths:
                       email: joe@example.com
                     bank_account_attributes:
                       bank_name: Test Bank
-                      bank_routing_number: "021000089"
-                      bank_account_number: "111111111111"
+                      bank_routing_number: '021000089'
+                      bank_account_number: '111111111111'
                       bank_account_type: checking
                       bank_account_holder_type: business
                       payment_type: bank_account
@@ -17793,7 +17793,16 @@ paths:
     post:
       operationId: post-subscription_groups_with_subs.j.json
       summary: Create Subscription Group with Multiple Subscriptions
-      description: Create subscription group with multiple subscriptions at once.
+      description: |-
+        Create multiple subscriptions at once under the same customer and consolidate them into a subscription group.
+
+        You must provide one and only one of the `payer_id`/`payer_reference`/`payer_attributes` for the customer attached to the group.
+
+        You must provide one and only one of the `payment_profile_id`/`credit_card_attributes`/`bank_account_attributes` for the payment profile attached to the group.
+
+        Only one of the `subscriptions` can have `"primary": true` attribute set.
+
+        When passing product to a subscription you can use either `product_id` or `product_handle`. You can also use `offer_id` instead.
       tags:
         - Subscription Groups
       responses:
@@ -17951,9 +17960,9 @@ paths:
                         type: object
                         properties:
                           product_handle:
-                            type: integer
-                          product_id:
                             type: string
+                          product_id:
+                            type: integer
                           product_price_point_id:
                             type: integer
                           product_price_point_handle:
@@ -18034,6 +18043,9 @@ paths:
                                   - integer
                               interval_unit:
                                 type: string
+                                enum:
+                                  - day
+                                  - month
                               trial_price_in_cents:
                                 type:
                                   - string
@@ -18044,6 +18056,9 @@ paths:
                                   - integer
                               trial_interval_unit:
                                 type: string
+                                enum:
+                                  - day
+                                  - month
                               initial_charge_in_cents:
                                 type:
                                   - string
@@ -18056,6 +18071,9 @@ paths:
                                   - integer
                               expiration_interval_unit:
                                 type: string
+                                enum:
+                                  - day
+                                  - month
                               tax_included:
                                 type: boolean
                           calendar_billing:
@@ -18075,6 +18093,121 @@ paths:
                               type: object
               required:
                 - subscription_group
+            examples:
+              Basic request:
+                value:
+                  subscription_group:
+                    payment_profile_id: 123
+                    payer_id: 123
+                    subscriptions:
+                      - product_id: 11
+                        primary: true
+                      - product_id: 12
+                      - product_id: 13
+              Create customer and payment profile in-place:
+                value:
+                  subscription_group:
+                    payer_attributes:
+                      first_name: John
+                      last_name: Doe
+                      email: john@example.com
+                      organization: 'Acme, Inc'
+                    credit_card_attributes:
+                      full_number: '4111111111111111'
+                      expiration_month: '12'
+                      expiration_year: '2031'
+                    subscriptions:
+                      - product_id: 123
+                        primary: true
+                      - product_handle: silver-plan
+                      - product_id: 124
+              Create credit card using Chargify.js token:
+                value:
+                  subscription_group:
+                    payer_id: 123
+                    credit_card_attributes:
+                      chargify_token: tok_19gnjsa9433u9b22
+                      last_four: '1111'
+                      card_type: visa
+                    subscriptions:
+                      - product_id: 11
+                        primary: true
+                      - product_id: 12
+                      - product_id: 13
+              Create bank account using Chargify.js token:
+                value:
+                  subscription_group:
+                    payer_id: 234
+                    bank_account_attributes:
+                      chargify_token: tok_19gnjsa9433u9b22
+                    subscriptions:
+                      - product_id: 11
+                        primary: true
+                      - product_id: 12
+                      - product_id: 13
+              Create group with subscription and customer metafields:
+                value:
+                  subscription_group:
+                    payer_attributes:
+                      first_name: John
+                      last_name: Doe
+                      email: john@example.com
+                      organization: 'Acme, Inc'
+                      metafields:
+                        win-over: ABCompany
+                    credit_card_attributes:
+                      full_number: '4111111111111111'
+                      expiration_month: '12'
+                      expiration_year: '2031'
+                    subscriptions:
+                      - product_id: 123
+                        primary: true
+                        metfields:
+                          mrr: $99
+                          discounted: false
+                      - product_handle: silver-plan
+                        metafields:
+                          mrr: $49
+                      - product_id: 124
+              Create subscription with components:
+                value:
+                  subscription_group:
+                    payment_profile_id: 123
+                    payer_id: 123
+                    subscriptions:
+                      - product_id: 11
+                        primary: true
+                        components:
+                          - component_id: 99
+                            allocated_quantity: 10
+                      - product_id: 12
+                      - product_id: 13
+              Create subscription with Custom Pricing:
+                value:
+                  subscription_group:
+                    payment_profile_id: 123
+                    payer_id: 123
+                    subscriptions:
+                      - product_id: 19
+                        custom_pricing:
+                          handle: custom-price
+                          price_in_cents: 9900
+                          interval: 1
+                          interval_unit: month
+                        primary: true
+                      - product_id: 12
+                        components:
+                          - component_id: 29
+                            allocated_quantity: 5
+                            custom_pricing:
+                              pricing_scheme: volume
+                              prices:
+                                - unit_price: '5'
+                                  starting_quantity: '1'
+                                  ending_quantity: '15'
+                                - unit_price: '2'
+                                  starting_quantity: '16'
+                      - product_id: 13
   /subscription_groups.json:
     post:
       summary: Create Subscription Group
@@ -24862,7 +24995,7 @@ components:
               type: string
         ach_agreement:
           type: object
-          description: (Optional) If passed, the proof of the authorized ACH agreement terms will be persisted.
+          description: '(Optional) If passed, the proof of the authorized ACH agreement terms will be persisted.'
           properties:
             agreement_terms:
               type: string

--- a/reference/Chargify-API.v1.yaml
+++ b/reference/Chargify-API.v1.yaml
@@ -18016,10 +18016,10 @@ paths:
                           description: (Required when creating a subscription with ACH. Optional when creating a subscription with GoCardless). The routing number of the bank. It becomes bank_code while passing via GoCardless API
                         bank_iban:
                           type: string
-                          description: '(Optional when creating a subscription with GoCardless). International Bank Account Number. Alternatively, local bank details can be provided'
+                          description: (Optional when creating a subscription with GoCardless). International Bank Account Number. Alternatively, local bank details can be provided
                         bank_branch_code:
                           type: string
-                          description: '(Optional when creating a subscription with GoCardless) Branch code. Alternatively, an IBAN can be provided'
+                          description: (Optional when creating a subscription with GoCardless) Branch code. Alternatively, an IBAN can be provided
                         bank_account_type:
                           type: string
                           enum:
@@ -18057,7 +18057,7 @@ paths:
                         properties:
                           product_handle:
                             type: string
-                            description: 'The API Handle of the product for which you are creating a subscription. Required, unless a `product_id` is given instead.'
+                            description: The API Handle of the product for which you are creating a subscription. Required, unless a `product_id` is given instead.
                           product_id:
                             type: integer
                             description: The Product ID of the product for which you are creating a subscription. You can pass either `product_id` or `product_handle`.
@@ -18069,7 +18069,7 @@ paths:
                             description: The user-friendly API handle of a product's particular price point.
                           offer_id:
                             type: integer
-                            description: 'Use in place of passing product and component information to set up the subscription with an existing offer. May be either the Chargify ID of the offer or its handle prefixed with `handle:`'
+                            description: Use in place of passing product and component information to set up the subscription with an existing offer. May be either the Chargify ID of the offer or its handle prefixed with `handle:`
                           reference:
                             type: string
                             description: The reference value (provided by your app) for the subscription itelf.
@@ -18078,7 +18078,7 @@ paths:
                             description: One of the subscriptions must be marked as primary in the group.
                           currency:
                             type: string
-                            description: '(Optional) If Multi-Currency is enabled and the currency is configured in Chargify, pass it at signup to create a subscription on a non-default currency. Note that you cannot update the currency of an existing subscription.'
+                            description: (Optional) If Multi-Currency is enabled and the currency is configured in Chargify, pass it at signup to create a subscription on a non-default currency. Note that you cannot update the currency of an existing subscription.
                           coupon_codes:
                             type: array
                             description: An array for all the coupons attached to the subscription.

--- a/reference/Chargify-API.v1.yaml
+++ b/reference/Chargify-API.v1.yaml
@@ -17789,10 +17789,10 @@ paths:
                     amount: '1'
                     memo: Deduction
       description: Credit will be removed from the subscription in the amount specified in the request body. The credit amount being deducted must be equal to or less than the current credit balance.
-  /subscription_groups_with_subs.json:
+  /subscription_groups/signup.json:
     post:
       operationId: post-subscription_groups_with_subs.j.json
-      summary: Create Subscription Group with Multiple Subscriptions
+      summary: Subscription Group Signup
       description: |-
         Create multiple subscriptions at once under the same customer and consolidate them into a subscription group.
 
@@ -18090,14 +18090,22 @@ paths:
                               type: object
                               properties:
                                 component_id:
-                                  type: string
+                                  type:
+                                    - string
+                                    - integer
                                   description: Required if passing any component to `components` attribute.
                                 allocated_quantity:
-                                  type: string
+                                  type:
+                                    - string
+                                    - integer
                                 unit_balance:
-                                  type: string
+                                  type:
+                                    - string
+                                    - integer
                                 price_point_id:
-                                  type: string
+                                  type:
+                                    - string
+                                    - integer
                                 custom_price:
                                   type: object
                                   description: Used in place of `price_point_id` to define a custom price point unique to the subscription. You still need to provide `component_id`.
@@ -18210,9 +18218,7 @@ paths:
                                   - immediate
                                   - delayed
                           metafields:
-                            type: array
-                            items:
-                              type: object
+                            type: object
               required:
                 - subscription_group
             examples:
@@ -18330,6 +18336,7 @@ paths:
                                 - unit_price: '2'
                                   starting_quantity: '16'
                       - product_id: 13
+    parameters: []
   /subscription_groups.json:
     post:
       summary: Create Subscription Group

--- a/reference/Chargify-API.v1.yaml
+++ b/reference/Chargify-API.v1.yaml
@@ -17791,7 +17791,7 @@ paths:
       description: Credit will be removed from the subscription in the amount specified in the request body. The credit amount being deducted must be equal to or less than the current credit balance.
   /subscription_groups/signup.json:
     post:
-      operationId: post-subscription_groups_with_subs.j.json
+      operationId: post-subscription_groups_signup.json
       summary: Subscription Group Signup
       description: |-
         Create multiple subscriptions at once under the same customer and consolidate them into a subscription group.

--- a/reference/Chargify-API.v1.yaml
+++ b/reference/Chargify-API.v1.yaml
@@ -17802,13 +17802,92 @@ paths:
 
         Only one of the `subscriptions` can have `"primary": true` attribute set.
 
-        When passing product to a subscription you can use either `product_id` or `product_handle`. You can also use `offer_id` instead.
+        When passing product to a subscription you can use either `product_id` or `product_handle` or `offer_id`. You can also use `custom_price` instead.
       tags:
         - Subscription Groups
       responses:
-        '200':
-          description: OK
+        '201':
+          description: Created
           headers: {}
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  uid:
+                    type: string
+                  scheme:
+                    type: integer
+                  customer_id:
+                    type: integer
+                  payment_profile_id:
+                    type: integer
+                  subscription_ids:
+                    type: array
+                    items:
+                      type: integer
+                  primary_subscription_id:
+                    type: integer
+                  next_assessment_at:
+                    type: string
+                  state:
+                    type: string
+                  cancel_at_end_of_period:
+                    type: boolean
+                  subscriptions:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: integer
+                        reference:
+                          type:
+                            - string
+                            - 'null'
+                        product_id:
+                          type: integer
+                        product_handle:
+                          type:
+                            - 'null'
+                            - string
+                        product_price_point_id:
+                          type: integer
+                        product_price_point_handle:
+                          type: string
+                        currency:
+                          type: string
+                        coupon_code:
+                          type:
+                            - string
+                            - 'null'
+                        total_revenue_in_cents:
+                          type: integer
+                        balance_in_cents:
+                          type: integer
+                  payment_collection_method:
+                    type: string
+                    enum:
+                      - remittance
+                      - automatic
+        '422':
+          description: Unprocessable Entity (WebDAV)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  errors:
+                    type: object
+                    properties:
+                      customer:
+                        type: object
+                      payment_profile:
+                        type: object
+                      subscriptions:
+                        type: object
+                required:
+                  - errors
       requestBody:
         content:
           application/json:
@@ -17831,6 +17910,7 @@ paths:
                       enum:
                         - automatic
                         - remittance
+                      default: automatic
                     payer_attributes:
                       type: object
                       properties:
@@ -17877,6 +17957,7 @@ paths:
                           type:
                             - string
                             - integer
+                          example: 4111111111111111
                         expiration_month:
                           type:
                             - string
@@ -17887,6 +17968,7 @@ paths:
                             - integer
                         chargify_token:
                           type: string
+                          example: tok_592nf92ng0sjd4300p
                         vault_token:
                           type: string
                         current_vault:
@@ -17913,6 +17995,7 @@ paths:
                           type: string
                         card_type:
                           type: string
+                          example: visa
                         customer_vault_token:
                           type: string
                         cvv:
@@ -17924,18 +18007,31 @@ paths:
                       properties:
                         bank_name:
                           type: string
+                          description: (Required when creating a subscription with ACH or GoCardless) The name of the bank where the customer’s account resides
                         bank_account_number:
                           type: string
+                          description: (Required when creating a subscription with ACH. Required when creating a subscription with GoCardless and bank_iban is blank) The customerʼs bank account number
                         bank_routing_number:
                           type: string
+                          description: (Required when creating a subscription with ACH. Optional when creating a subscription with GoCardless). The routing number of the bank. It becomes bank_code while passing via GoCardless API
                         bank_iban:
                           type: string
+                          description: '(Optional when creating a subscription with GoCardless). International Bank Account Number. Alternatively, local bank details can be provided'
                         bank_branch_code:
                           type: string
+                          description: '(Optional when creating a subscription with GoCardless) Branch code. Alternatively, an IBAN can be provided'
                         bank_account_type:
                           type: string
+                          enum:
+                            - checking
+                            - savings
+                          default: checking
                         bank_account_holder_type:
                           type: string
+                          enum:
+                            - personal
+                            - business
+                          default: personal
                         payment_type:
                           type: string
                         billing_address:
@@ -17961,22 +18057,31 @@ paths:
                         properties:
                           product_handle:
                             type: string
+                            description: 'The API Handle of the product for which you are creating a subscription. Required, unless a `product_id` is given instead.'
                           product_id:
                             type: integer
+                            description: The Product ID of the product for which you are creating a subscription. You can pass either `product_id` or `product_handle`.
                           product_price_point_id:
                             type: integer
+                            description: The ID of the particular price point on the product.
                           product_price_point_handle:
                             type: string
+                            description: The user-friendly API handle of a product's particular price point.
                           offer_id:
                             type: integer
+                            description: 'Use in place of passing product and component information to set up the subscription with an existing offer. May be either the Chargify ID of the offer or its handle prefixed with `handle:`'
                           reference:
                             type: string
+                            description: The reference value (provided by your app) for the subscription itelf.
                           primary:
                             type: boolean
+                            description: One of the subscriptions must be marked as primary in the group.
                           currency:
                             type: string
+                            description: '(Optional) If Multi-Currency is enabled and the currency is configured in Chargify, pass it at signup to create a subscription on a non-default currency. Note that you cannot update the currency of an existing subscription.'
                           coupon_codes:
                             type: array
+                            description: An array for all the coupons attached to the subscription.
                             items:
                               type: string
                           components:
@@ -17986,6 +18091,7 @@ paths:
                               properties:
                                 component_id:
                                   type: string
+                                  description: Required if passing any component to `components` attribute.
                                 allocated_quantity:
                                   type: string
                                 unit_balance:
@@ -17994,9 +18100,15 @@ paths:
                                   type: string
                                 custom_price:
                                   type: object
+                                  description: Used in place of `price_point_id` to define a custom price point unique to the subscription. You still need to provide `component_id`.
                                   properties:
                                     pricing_scheme:
                                       type: string
+                                      enum:
+                                        - per_unit
+                                        - stairstep
+                                        - volume
+                                        - tiered
                                     prices:
                                       type: array
                                       items:
@@ -18015,6 +18127,11 @@ paths:
                                         properties:
                                           pricing_scheme:
                                             type: string
+                                            enum:
+                                              - per_unit
+                                              - stairstep
+                                              - volume
+                                              - tiered
                                           prices:
                                             type: array
                                             items:
@@ -18028,6 +18145,7 @@ paths:
                                                   type: string
                           custom_price:
                             type: object
+                            description: Used in place of `product_price_point_id` to define a custom price point unique to the subscription. You still need to pass `product_id` or `product_handle`.
                             properties:
                               name:
                                 type: string
@@ -18037,15 +18155,18 @@ paths:
                                 type:
                                   - string
                                   - integer
+                                description: Required if using `custom_price` attribute.
                               interval:
                                 type:
                                   - string
                                   - integer
+                                description: Required if using `custom_price` attribute.
                               interval_unit:
                                 type: string
                                 enum:
                                   - day
                                   - month
+                                description: Required if using `custom_price` attribute.
                               trial_price_in_cents:
                                 type:
                                   - string
@@ -18081,6 +18202,7 @@ paths:
                             properties:
                               snap_day:
                                 type: string
+                                description: A day of month that subscription will be processed on. Can be 1 up to 28 or 'end'.
                               calendar_billing_first_charge:
                                 type: string
                                 enum:

--- a/reference/Chargify-API.v1.yaml
+++ b/reference/Chargify-API.v1.yaml
@@ -13416,7 +13416,6 @@ paths:
             }
           }
         ```
-
       requestBody:
         content:
           application/json:
@@ -13735,8 +13734,8 @@ paths:
                       email: joe@example.com
                     bank_account_attributes:
                       bank_name: Test Bank
-                      bank_routing_number: 021000089
-                      bank_account_number: 111111111111
+                      bank_routing_number: "021000089"
+                      bank_account_number: "111111111111"
                       bank_account_type: checking
                       bank_account_holder_type: business
                       payment_type: bank_account
@@ -17790,6 +17789,292 @@ paths:
                     amount: '1'
                     memo: Deduction
       description: Credit will be removed from the subscription in the amount specified in the request body. The credit amount being deducted must be equal to or less than the current credit balance.
+  /subscription_groups_with_subs.json:
+    post:
+      operationId: post-subscription_groups_with_subs.j.json
+      summary: Create Subscription Group with Multiple Subscriptions
+      description: Create subscription group with multiple subscriptions at once.
+      tags:
+        - Subscription Groups
+      responses:
+        '200':
+          description: OK
+          headers: {}
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                subscription_group:
+                  type: object
+                  required:
+                    - subscriptions
+                  properties:
+                    payment_profile_id:
+                      type: integer
+                    payer_id:
+                      type: integer
+                    payer_reference:
+                      type: string
+                    payment_collection_method:
+                      type: string
+                      enum:
+                        - automatic
+                        - remittance
+                    payer_attributes:
+                      type: object
+                      properties:
+                        first_name:
+                          type: string
+                        last_name:
+                          type: string
+                        email:
+                          type: string
+                        cc_emails:
+                          type: string
+                        organization:
+                          type: string
+                        reference:
+                          type: string
+                        address:
+                          type: string
+                        address_2:
+                          type: string
+                        city:
+                          type: string
+                        state:
+                          type: string
+                        zip:
+                          type: string
+                        country:
+                          type: string
+                        phone:
+                          type: string
+                        locale:
+                          type: string
+                        vat_number:
+                          type: string
+                        tax_exempt:
+                          type: string
+                        tax_exempt_reason:
+                          type: string
+                        metafields:
+                          type: object
+                    credit_card_attributes:
+                      type: object
+                      properties:
+                        full_number:
+                          type:
+                            - string
+                            - integer
+                        expiration_month:
+                          type:
+                            - string
+                            - integer
+                        expiration_year:
+                          type:
+                            - string
+                            - integer
+                        chargify_token:
+                          type: string
+                        vault_token:
+                          type: string
+                        current_vault:
+                          type: string
+                        gateway_handle:
+                          type: string
+                        first_name:
+                          type: string
+                        last_name:
+                          type: string
+                        billing_address:
+                          type: string
+                        billing_address_2:
+                          type: string
+                        billing_city:
+                          type: string
+                        billing_state:
+                          type: string
+                        billing_zip:
+                          type: string
+                        billing_country:
+                          type: string
+                        last_four:
+                          type: string
+                        card_type:
+                          type: string
+                        customer_vault_token:
+                          type: string
+                        cvv:
+                          type: string
+                        payment_type:
+                          type: string
+                    bank_account_attributes:
+                      type: object
+                      properties:
+                        bank_name:
+                          type: string
+                        bank_account_number:
+                          type: string
+                        bank_routing_number:
+                          type: string
+                        bank_iban:
+                          type: string
+                        bank_branch_code:
+                          type: string
+                        bank_account_type:
+                          type: string
+                        bank_account_holder_type:
+                          type: string
+                        payment_type:
+                          type: string
+                        billing_address:
+                          type: string
+                        billing_city:
+                          type: string
+                        billing_state:
+                          type: string
+                        billing_zip:
+                          type: string
+                        billing_country:
+                          type: string
+                        chargify_token:
+                          type: string
+                        current_vault:
+                          type: string
+                        gateway_handle:
+                          type: string
+                    subscriptions:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          product_handle:
+                            type: integer
+                          product_id:
+                            type: string
+                          product_price_point_id:
+                            type: integer
+                          product_price_point_handle:
+                            type: string
+                          offer_id:
+                            type: integer
+                          reference:
+                            type: string
+                          primary:
+                            type: boolean
+                          currency:
+                            type: string
+                          coupon_codes:
+                            type: array
+                            items:
+                              type: string
+                          components:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                component_id:
+                                  type: string
+                                allocated_quantity:
+                                  type: string
+                                unit_balance:
+                                  type: string
+                                price_point_id:
+                                  type: string
+                                custom_price:
+                                  type: object
+                                  properties:
+                                    pricing_scheme:
+                                      type: string
+                                    prices:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          unit_price:
+                                            type: string
+                                          starting_quantity:
+                                            type: string
+                                          ending_quantity:
+                                            type: string
+                                    overage_pricing:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          pricing_scheme:
+                                            type: string
+                                          prices:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                unit_price:
+                                                  type: string
+                                                starting_quantity:
+                                                  type: string
+                                                ending_quantity:
+                                                  type: string
+                          custom_price:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              handle:
+                                type: string
+                              price_in_cents:
+                                type:
+                                  - string
+                                  - integer
+                              interval:
+                                type:
+                                  - string
+                                  - integer
+                              interval_unit:
+                                type: string
+                              trial_price_in_cents:
+                                type:
+                                  - string
+                                  - integer
+                              trial_interval:
+                                type:
+                                  - string
+                                  - integer
+                              trial_interval_unit:
+                                type: string
+                              initial_charge_in_cents:
+                                type:
+                                  - string
+                                  - integer
+                              initial_charge_after_trial:
+                                type: boolean
+                              expiration_interval:
+                                type:
+                                  - string
+                                  - integer
+                              expiration_interval_unit:
+                                type: string
+                              tax_included:
+                                type: boolean
+                          calendar_billing:
+                            type: object
+                            properties:
+                              snap_day:
+                                type: string
+                              calendar_billing_first_charge:
+                                type: string
+                                enum:
+                                  - prorated
+                                  - immediate
+                                  - delayed
+                          metafields:
+                            type: array
+                            items:
+                              type: object
+              required:
+                - subscription_group
   /subscription_groups.json:
     post:
       summary: Create Subscription Group


### PR DESCRIPTION
We have a possibility to create a Subscription group with subscription attributes passed - it will create each subscription and put them in one group. Recently, we improved this functionality and we want to separate that into another endpoint (https://github.com/maxio-com/chargify/pull/22122).

This PR documents all the properties you can pass to Subscription Group Signup.
Simultaneously with this PR, we will remove the Feature Flag (Chargify PR: https://github.com/maxio-com/chargify/pull/22163).