### PR TITLE
add paying invoice via existing payment frofile from API to docs

### DIFF
--- a/reference/Chargify-API.v1.yaml
+++ b/reference/Chargify-API.v1.yaml
@@ -9931,7 +9931,7 @@ paths:
 
         ## Create a Payment from the existing payment profile
 
-        In order to apply a payment to an invoice using an existing payment profile, specify `type` as `payment`, the amount less than the invoice total, and the customer's `payment_profile_id`. Id of a payment profile might be retrieved via the Payment Profiles API endpoint.
+        In order to apply a payment to an invoice using an existing payment profile, specify `type` as `payment`, the amount less than the invoice total, and the customer's `payment_profile_id`. The ID of a payment profile might be retrieved via the Payment Profiles API endpoint.
 
         ```
         {

--- a/reference/Chargify-API.v1.yaml
+++ b/reference/Chargify-API.v1.yaml
@@ -9927,7 +9927,21 @@ paths:
                 $ref: '#/components/schemas/Invoice'
       operationId: post-invoices-uid-payments.json
       description: |-
-        This API call should be used when you want to record an external payment against a specific invoice. If you would like to apply a payment across multiple invoices, you can use the Bulk Payment endpoint.
+        This API call should be used when you want to record a payment of a given type against a specific invoice. If you would like to apply a payment across multiple invoices, you can use the Bulk Payment endpoint.
+
+        ## Create a Payment from the existing payment profile
+
+        In order to apply a payment to an invoice using existing payment profile, specify `type` as `payment`, amount with number lesser then invoice total and customer's `payment_profile_id`. Id of a payment profile might be retrieved via payment profiles API endpoint.
+
+        ```
+        {
+          "type": "payment",
+          "payment": {
+            "amount": 10.00,
+            "payment_profile_id": 123
+          }
+        }
+        ```
 
         ## Create a Payment from the Subscription's Prepayment Account
 
@@ -9999,6 +10013,7 @@ paths:
                     - external
                     - prepayment
                     - service_credit
+                    - payment
             examples:
               Example 1:
                 value:

--- a/reference/Chargify-API.v1.yaml
+++ b/reference/Chargify-API.v1.yaml
@@ -9931,7 +9931,7 @@ paths:
 
         ## Create a Payment from the existing payment profile
 
-        In order to apply a payment to an invoice using existing payment profile, specify `type` as `payment`, amount with number lesser then invoice total and customer's `payment_profile_id`. Id of a payment profile might be retrieved via payment profiles API endpoint.
+        In order to apply a payment to an invoice using an existing payment profile, specify `type` as `payment`, the amount less than the invoice total, and the customer's `payment_profile_id`. Id of a payment profile might be retrieved via the Payment Profiles API endpoint.
 
         ```
         {


### PR DESCRIPTION
Why?
Paying an invoice with an existing payment profile was added here: https://github.com/maxio-com/chargify/pull/8204/files#diff-90785117b8c410cbd27a1c8a4139d4519213aadbab76d5b1e1bc62cc80f0de28R7
But IMO it was meant mostly to cover UI cases (paying invoice with the buton).

But the controller was already handling API requests for external payments (that was documented):
https://github.com/maxio-com/chargify/pull/8111/files

What?
As a join of these two facts, appying real payment via api became available but wasn't documented. Let's add docs for it.