### PR TITLE
Update OperationIds for human readable labels

### DIFF
--- a/reference/Chargify-API.v1.yaml
+++ b/reference/Chargify-API.v1.yaml
@@ -386,7 +386,7 @@ paths:
                         body: 'id=141765008&event=payment_success&payload[site][id]=31615&payload[site][subdomain]=general-goods&payload[subscription][id]=15100141&payload[subscription][state]=active&payload[subscription][trial_started_at]=&payload[subscription][trial_ended_at]=&payload[subscription][activated_at]=2016-11-04%2017%3A06%3A43%20-0400&payload[subscription][created_at]=2016-11-04%2017%3A06%3A42%20-0400&payload[subscription][updated_at]=2016-11-08%2016%3A22%3A22%20-0500&payload[subscription][expires_at]=&payload[subscription][balance_in_cents]=0&payload[subscription][current_period_ends_at]=2016-11-09%2016%3A06%3A42%20-0500&payload[subscription][next_assessment_at]=2016-11-09%2016%3A06%3A42%20-0500&payload[subscription][canceled_at]=&payload[subscription][cancellation_message]=&payload[subscription][next_product_id]=&payload[subscription][cancel_at_end_of_period]=false&payload[subscription][payment_collection_method]=automatic&payload[subscription][snap_day]=&payload[subscription][cancellation_method]=&payload[subscription][current_period_started_at]=2016-11-08%2016%3A06%3A42%20-0500&payload[subscription][previous_state]=active&payload[subscription][signup_payment_id]=161034048&payload[subscription][signup_revenue]=64.00&payload[subscription][delayed_cancel_at]=&payload[subscription][coupon_code]=&payload[subscription][total_revenue_in_cents]=32000&payload[subscription][product_price_in_cents]=1000&payload[subscription][product_version_number]=7&payload[subscription][payment_type]=credit_card&payload[subscription][referral_code]=pggn84&payload[subscription][coupon_use_count]=&payload[subscription][coupon_uses_allowed]=&payload[subscription][customer][id]=14585695&payload[subscription][customer][first_name]=Test&payload[subscription][customer][last_name]=Test&payload[subscription][customer][organization]=&payload[subscription][customer][email]=pookie999%40example.com&payload[subscription][customer][created_at]=2016-11-04%2017%3A06%3A42%20-0400&payload[subscription][customer][updated_at]=2016-11-04%2017%3A06%3A45%20-0400&payload[subscription][customer][reference]=&payload[subscription][customer][address]=&payload[subscription][customer][address_2]=&payload[subscription][customer][city]=&payload[subscription][customer][state]=&payload[subscription][customer][zip]=&payload[subscription][customer][country]=&payload[subscription][customer][phone]=&payload[subscription][customer][portal_invite_last_sent_at]=2016-11-04%2017%3A06%3A45%20-0400&payload[subscription][customer][portal_invite_last_accepted_at]=&payload[subscription][customer][verified]=false&payload[subscription][customer][portal_customer_created_at]=2016-11-04%2017%3A06%3A45%20-0400&payload[subscription][customer][cc_emails]=&payload[subscription][product][id]=3792003&payload[subscription][product][name]=%2410%20Basic%20Plan&payload[subscription][product][handle]=basic&payload[subscription][product][description]=lorem%20ipsum&payload[subscription][product][accounting_code]=basic&payload[subscription][product][request_credit_card]=false&payload[subscription][product][expiration_interval]=&payload[subscription][product][expiration_interval_unit]=never&payload[subscription][product][created_at]=2016-03-24%2013%3A38%3A39%20-0400&payload[subscription][product][updated_at]=2016-11-03%2013%3A03%3A05%20-0400&payload[subscription][product][price_in_cents]=1000&payload[subscription][product][interval]=1&payload[subscription][product][interval_unit]=day&payload[subscription][product][initial_charge_in_cents]=&payload[subscription][product][trial_price_in_cents]=&payload[subscription][product][trial_interval]=&payload[subscription][product][trial_interval_unit]=month&payload[subscription][product][archived_at]=&payload[subscription][product][require_credit_card]=false&payload[subscription][product][return_params]=&payload[subscription][product][taxable]=false&payload[subscription][product][update_return_url]=&payload[subscription][product][initial_charge_after_trial]=false&payload[subscription][product][version_number]=7&payload[subscription][product][update_return_params]=&payload[subscription][product][product_family][id]=527890&payload[subscription][product][product_family][name]=Acme%20Projects&payload[subscription][product][product_family][description]=&payload[subscription][product][product_family][handle]=billing-plans&payload[subscription][product][product_family][accounting_code]=&payload[subscription][product][public_signup_pages][id]=281054&payload[subscription][product][public_signup_pages][return_url]=http%3A%2F%2Fwww.example.com%3Fsuccessfulsignup&payload[subscription][product][public_signup_pages][return_params]=&payload[subscription][product][public_signup_pages][url]=https%3A%2F%2Fgeneral-goods.chargify.com%2Fsubscribe%2Fkqvmfrbgd89q%2Fbasic&payload[subscription][product][public_signup_pages][id]=281240&payload[subscription][product][public_signup_pages][return_url]=&payload[subscription][product][public_signup_pages][return_params]=&payload[subscription][product][public_signup_pages][url]=https%3A%2F%2Fgeneral-goods.chargify.com%2Fsubscribe%2Fdkffht5dxfd8%2Fbasic&payload[subscription][product][public_signup_pages][id]=282694&payload[subscription][product][public_signup_pages][return_url]=&payload[subscription][product][public_signup_pages][return_params]=&payload[subscription][product][public_signup_pages][url]=https%3A%2F%2Fgeneral-goods.chargify.com%2Fsubscribe%2Fjwffwgdd95s8%2Fbasic&payload[subscription][credit_card][id]=10102821&payload[subscription][credit_card][first_name]=Pookie&payload[subscription][credit_card][last_name]=Test&payload[subscription][credit_card][masked_card_number]=XXXX-XXXX-XXXX-1&payload[subscription][credit_card][card_type]=bogus&payload[subscription][credit_card][expiration_month]=10&payload[subscription][credit_card][expiration_year]=2020&payload[subscription][credit_card][customer_id]=14585695&payload[subscription][credit_card][current_vault]=bogus&payload[subscription][credit_card][vault_token]=1&payload[subscription][credit_card][billing_address]=&payload[subscription][credit_card][billing_city]=&payload[subscription][credit_card][billing_state]=&payload[subscription][credit_card][billing_zip]=&payload[subscription][credit_card][billing_country]=&payload[subscription][credit_card][customer_vault_token]=&payload[subscription][credit_card][billing_address_2]=&payload[subscription][credit_card][payment_type]=credit_card&payload[subscription][credit_card][site_gateway_setting_id]=&payload[subscription][credit_card][gateway_handle]=&payload[transaction][id]=161537369&payload[transaction][subscription_id]=15100141&payload[transaction][type]=Payment&payload[transaction][kind]=&payload[transaction][transaction_type]=payment&payload[transaction][success]=true&payload[transaction][amount_in_cents]=6400&payload[transaction][memo]=Pookie%20Test%20-%20%2410%20Basic%20Plan%3A%20Renewal%20payment&payload[transaction][created_at]=2016-11-08%2016%3A22%3A20%20-0500&payload[transaction][starting_balance_in_cents]=6400&payload[transaction][ending_balance_in_cents]=0&payload[transaction][gateway_used]=bogus&payload[transaction][gateway_transaction_id]=53433&payload[transaction][gateway_response_code]=&payload[transaction][gateway_order_id]=&payload[transaction][payment_id]=&payload[transaction][product_id]=3792003&payload[transaction][tax_id]=&payload[transaction][component_id]=&payload[transaction][statement_id]=80168049&payload[transaction][customer_id]=14585695&payload[transaction][card_number]=XXXX-XXXX-XXXX-1&payload[transaction][card_expiration]=10%2F2020&payload[transaction][card_type]=bogus&payload[transaction][refunded_amount_in_cents]=0&payload[transaction][invoice_id]=&payload[event_id]=347299364'
                         signature: fbcf2f6be579f9658cff90c4373e0ca2
                         signature_hmac_sha_256: db96654f5456c5460062feb944ac8bb1418f9d181ae04a8ed982fe9ffdca8de1
-      operationId: get-webhooks.json
+      operationId: readWebhooks
       description: |-
         ## Webhooks Intro
 
@@ -625,7 +625,7 @@ paths:
                         - payment_success
                         - payment_failure
                         - refund_failure
-      operationId: get-endpoints.json
+      operationId: readWebhookEndpoints
       description: This method returns created endpoints for site.
   '/endpoints/{endpoint_id}.json':
     parameters:
@@ -745,7 +745,7 @@ paths:
                         net_terms_on_remittance_signups_enabled: false
                         custom_net_terms_enabled: false
                       test: true
-      operationId: get-site.json
+      operationId: readSite
       description: |-
         This endpoint allows you to fetch some site data.
 
@@ -879,7 +879,7 @@ paths:
                         sticky: false
                         subscription_id: 100046
                         updated_at: '2015-06-15T13:26:33-04:00'
-      operationId: get-subscriptions-subscription_id-notes.json
+      operationId: readSubscriptionNotes
       description: Use this method to retrieve a list of Notes associated with a Subscription. The response will be an array of Notes.
       parameters:
         - schema:
@@ -932,7 +932,7 @@ paths:
                       sticky: false
                       subscription_id: 100046
                       updated_at: '2015-06-15T13:28:12-04:00'
-      operationId: get-subscriptions-subscription_id-notes-note_id-.json
+      operationId: readSubscriptionNote
       description: 'Once you have obtained the ID of the note you wish to read, use this method to show a particular note attached to a subscription.'
     put:
       summary: Update Subscription Note
@@ -1176,7 +1176,7 @@ paths:
                         portal_invite_last_accepted_at: null
                         tax_exempt: false
                         parent_id: null
-      operationId: get-customers.json
+      operationId: readCustomers
       description: |-
         This request will by default list all customers associated with your Site.
 
@@ -1270,7 +1270,7 @@ paths:
                 properties:
                   customer:
                     $ref: ../models/Customer.yaml
-      operationId: get-customers-id-.json
+      operationId: readCustomer
       description: This method allows to retrieve the Customer properties by Chargify-generated Customer ID.
       parameters: []
     put:
@@ -1369,7 +1369,7 @@ paths:
                 properties:
                   customer:
                     $ref: ../models/Customer.yaml
-      operationId: get-customers-lookup.json
+      operationId: readCustomerByReference
       description: Use this method to return the customer object if you have the unique **Reference ID (Your App)** value handy. It will return a single match.
       parameters:
         - schema:
@@ -1399,7 +1399,7 @@ paths:
                 type: array
                 items:
                   $ref: ../models/Subscription.yaml
-      operationId: get-customers-customer_id-subscriptions.json
+      operationId: readSubscriptionsByCustomer
       description: This method lists all subscriptions that belong to a customer.
   '/portal/customers/{customer_id}/enable.json':
     parameters:
@@ -1540,7 +1540,7 @@ paths:
                   value:
                     errors:
                       error: Too many requests for this customer's management link
-      operationId: get-portal-customers-customer_id-management_link.json
+      operationId: readCustomerPortalLink
       description: |-
         This method will provide to the API user the exact URL required for a subscriber to access the Billing Portal.
 
@@ -1722,7 +1722,7 @@ paths:
                       revenue_today: '$1,405.12'
                       revenue_this_month: '$10,000.00'
                       revenue_this_year: '$27,935.24'
-      operationId: get-stats.json
+      operationId: readSiteStats
       description: |-
         The Stats API is a very basic view of some Site-level stats. This API call only answers with JSON responses. An XML version is not provided.
 
@@ -1778,7 +1778,7 @@ paths:
                 Example:
                   value:
                     errors: Referral code is invalid.
-      operationId: get-referral_codes-validate.json
+      operationId: validateReferralCode
       parameters:
         - schema:
             type: string
@@ -1878,7 +1878,7 @@ paths:
       summary: List Reason Codes
       tags:
         - Reason Codes
-      operationId: get-reason_codes.json
+      operationId: readReasonCodes
       responses:
         '200':
           description: OK
@@ -1953,7 +1953,7 @@ paths:
                     $ref: '#/components/schemas/Reason-Code'
         '404':
           description: Not Found
-      operationId: get-reason_codes-reason_code_id-.json
+      operationId: readReasonCode
       description: This method gives a merchant the option to retrieve a list of a particular code for a given Site by providing the unique numerical ID of the code.
     put:
       summary: Update Reason Code
@@ -2162,7 +2162,7 @@ paths:
                         data_count: 0
                         input_type: string
                         enum: null
-      operationId: get-resource_type-metafields.json
+      operationId: readSiteMetafields
       description: This endpoint lists metafields associated with a site. The metafield description and usage is contained in the response.
       parameters:
         - schema:
@@ -2343,7 +2343,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Paginated-Metadata'
-      operationId: get-resource_type-resource_id-metadata.json
+      operationId: readMetadata
       description: |-
         This request will list all of the metadata belonging to a particular resource (ie. subscription, customer) that is specified.
 
@@ -2459,7 +2459,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Paginated-Metadata'
-      operationId: get-resource_type-metadata.json
+      operationId: readResourceMetadataFields
       description: |-
         This method will provide you information on usage of metadata across your selected resource (ie. subscriptions, customers)
 
@@ -2722,7 +2722,7 @@ paths:
                             name: test
                             handle: null
                         use_site_exchange_rate: true
-      operationId: get-product_families-product_family_id-coupons.json
+      operationId: readProductFamilyCoupons
       description: |-
         List coupons for a specific Product Family in a Site.
 
@@ -2819,7 +2819,7 @@ paths:
                 properties:
                   coupon:
                     $ref: '#/components/schemas/Coupon'
-      operationId: get-coupons-find.json
+      operationId: readCouponByCode
       description: |-
         You can search for a coupon via the API with the find method. By passing a code parameter, the find will attempt to locate a coupon that matches that code. If no coupon is found, a 404 is returned.
 
@@ -2887,7 +2887,7 @@ paths:
                       stackable: true
                       compounding_strategy: compound
                       coupon_restrictions: []
-      operationId: get-product_families-product_family_id-coupons-coupon_id-.json
+      operationId: readCoupon
       description: |-
         You can retrieve the Coupon via the API with the Show method. You must identify the Coupon in this call by the ID parameter that Chargify assigns.
         If instead you would like to find a Coupon using a Coupon code, see the Coupon Find method.
@@ -3067,7 +3067,7 @@ paths:
                             item_id: 0
                             name: string
                             handle: string
-      operationId: get-coupons.json
+      operationId: readCoupons
       description: |-
         You can retrieve a list of coupons.
 
@@ -3249,7 +3249,7 @@ paths:
                       savings_in_cents: 3000
                       revenue: 20
                       revenue_in_cents: 2000
-      operationId: get-product_families-product_family_id-coupons-coupon_id-usage.json
+      operationId: readCouponUsage
       description: 'This request will provide details about the coupon usage as an array of data hashes, one per product.'
   /coupons/validate.json:
     get:
@@ -3304,7 +3304,7 @@ paths:
                 Example:
                   value:
                     errors: Coupon code could not be found.
-      operationId: get-coupons-validate.json
+      operationId: validateCouponCode
       description: |-
         You can verify if a specific coupon code is valid using the `validate` method. This method is useful for validating coupon codes that are entered by a customer. If the coupon is found and is valid, the coupon will be returned with a 200 status code.
 
@@ -3509,7 +3509,7 @@ paths:
       summary: List Coupon Subcodes
       tags:
         - Coupons
-      operationId: get-coupons-coupon_id-codes.json
+      operationId: readCouponSubcodes
       responses:
         '200':
           description: OK
@@ -3789,7 +3789,7 @@ paths:
               schema:
                 type: array
                 items: {}
-      operationId: get-events.json
+      operationId: readSiteEventActivity
       description: |-
         ## Events Intro
 
@@ -3997,7 +3997,7 @@ paths:
                         subscription_id: 14900541
                         created_at: '2016-11-01T12:41:25-04:00'
                         event_specific_data: null
-      operationId: get-subscriptions-subscription_id-events.json
+      operationId: readSubscriptionEventActivity
       description: |-
         The following request will return a list of events for a subscription.
 
@@ -4089,7 +4089,7 @@ paths:
                 Example:
                   value:
                     count: 144
-      operationId: get-events-count.json
+      operationId: readTotalEventCount
       parameters:
         - schema:
             type: integer
@@ -4211,7 +4211,7 @@ paths:
                         plan_amount_formatted: '$99,135.93'
                         usage_amount_in_cents: 2000
                         usage_amount_formatted: $20.00
-      operationId: get-mrr.json
+      operationId: readLegacyMrr
       description: 'This endpoint returns your site''s current MRR, including plan and usage breakouts.'
       parameters:
         - schema:
@@ -5087,7 +5087,7 @@ paths:
                       created_at: '2019-08-02T05:54:53-04:00'
                       default_price_point_name: Original
                       product_family_name: Chargify
-      operationId: get-components-lookup.json
+      operationId: readComponentByHandle
       parameters:
         - schema:
             type: string
@@ -5147,7 +5147,7 @@ paths:
                       created_at: '2019-08-02T05:54:53-04:00'
                       default_price_point_name: Original
                       product_family_name: Chargify
-      operationId: get-product_families-product_family_id-components-component_id-.json
+      operationId: readComponentById
       description: |-
         This request will return information regarding a component from a specific product family.
 
@@ -5298,7 +5298,7 @@ paths:
                         default_price_point_name: Original
                         product_family_name: Chargify
                         use_site_exchange_rate: true
-      operationId: get-components.json
+      operationId: readComponents
       parameters:
         - schema:
             type: string
@@ -5487,7 +5487,7 @@ paths:
                         default_price_point_name: Original
                         product_family_name: Chargify
                         use_site_exchange_rate: true
-      operationId: get-product_families-product_family_id-components.json
+      operationId: readComponentsByProductFamily
       description: This request will return a list of components for a particular product family.
       parameters:
         - schema:
@@ -5678,7 +5678,7 @@ paths:
                             starting_quantity: 1
                             ending_quantity: null
                             unit_price: '4.0'
-      operationId: get-components-component_id-price_points.json
+      operationId: readComponentPrices
       description: |-
         Use this endpoint to read current price points that are associated with a component.
 
@@ -6205,7 +6205,7 @@ paths:
                               recurring: true
                           subscription_id: 12355
                           subscriber_name: Amy Smith
-      operationId: get-mrr_movements.json
+      operationId: readLegacyMrrMovements
       description: |-
         This endpoint returns your site's MRR movements.
 
@@ -6349,7 +6349,7 @@ paths:
                     tax_code: D0000000
     get:
       summary: List Products for Product Family
-      operationId: get-product_families-product_family_id-products.json
+      operationId: readProductsByFamily
       responses:
         '200':
           description: OK
@@ -6584,7 +6584,7 @@ paths:
                         accounting_code: null
                       public_signup_pages: []
                       product_price_point_name: Default
-      operationId: get-products-product_id-.json
+      operationId: readProduct
       description: This endpoint allows you to read the current details of a product that you've created in Chargify.
     put:
       summary: Update Product
@@ -6808,7 +6808,7 @@ paths:
                           return_params: engine=md7a
                           url: 'https://general-goods.chargify.com/subscribe/m6tbcq4mcgpw/no-cost-product'
                       product_price_point_name: Default
-      operationId: get-products-handle-api_handle-.json
+      operationId: readProductByHandle
       description: This method allows to retrieve a Product object by its `api_handle`.
   /product_families.json:
     post:
@@ -6893,7 +6893,7 @@ paths:
                         accounting_code: null
                         created_at: '2014-04-16T12:41:13-06:00'
                         updated_at: '2014-04-16T12:41:13-06:00'
-      operationId: get-product_families.json
+      operationId: readProductFamilies
       description: This method allows to retrieve a list of Product Families for a site.
       parameters:
         - schema:
@@ -6955,7 +6955,7 @@ paths:
                       description: ''
                       handle: billing-plans
                       accounting_code: null
-      operationId: get-product_families-id-.json
+      operationId: readProductFamily
       description: |-
         This method allows to retrieve a Product Family via the `product_family_id`. The response will contain a Product Family object.
 
@@ -7069,7 +7069,7 @@ paths:
                         archived_at: 'Tue, 30 Oct 2018 18:49:47 EDT -04:00'
                         created_at: 'Tue, 23 Oct 2018 18:49:47 EDT -04:00'
                         updated_at: 'Tue, 23 Oct 2018 18:49:47 EDT -04:00'
-      operationId: get-products-product_id-price_points.json
+      operationId: readProductPricePoints
       parameters:
         - schema:
             type: integer
@@ -7208,7 +7208,7 @@ paths:
                       archived_at: 'Tue, 30 Oct 2018 18:49:47 EDT -04:00'
                       created_at: 'Tue, 23 Oct 2018 18:49:47 EDT -04:00'
                       updated_at: 'Tue, 23 Oct 2018 18:49:47 EDT -04:00'
-      operationId: get-products-product_id-price_points-price_point_id-.json
+      operationId: readProductPricePoint
       description: Use this endpoint to retrieve details for a specific product price point.
       parameters:
         - schema:
@@ -8265,7 +8265,7 @@ paths:
                         payment_type: bank_account
                         site_gateway_setting_id: 1
                         gateway_handle: null
-      operationId: get-payment_profiles.json
+      operationId: readPaymentProfiles
       description: 'This method will return all of the active `payment_profiles` for a Site, or for one Customer within a site.  If no payment profiles are found, this endpoint will return an empty array, not a 404.'
       parameters:
         - schema:
@@ -8448,7 +8448,7 @@ paths:
                       payment_type: bank_account
                       site_gateway_setting_id: 1
                       gateway_handle: null
-      operationId: get-payment_profiles-payment_profile_id-.json
+      operationId: readPaymentProfile
       description: |-
         Using the GET method you can retrieve a Payment Profile identified by its unique ID.
 
@@ -9211,7 +9211,7 @@ paths:
                         refund_amount: '0.0'
                         due_amount: '0.0'
                     public_url: 'https://www.chargifypay.com/invoice/inv_8jzrw74xq8kxr?token=fb6kpjz5rcr2vttyjs4rcv6y'
-      operationId: get-invoices.json
+      operationId: readInvoices
       description: 'By default, invoices returned on the index will only include totals, not detailed breakdowns for `line_items`, `discounts`, `taxes`, `credits`, `payments`, `custom_fields`, or `refunds`. To include breakdowns, pass the specific field as a key in the query with a value set to `true`.'
       parameters:
         - schema:
@@ -9481,7 +9481,7 @@ paths:
                     refunds: []
                     custom_fields: []
                     public_url: 'https://www.chargifypay.com/invoice/inv_8jzrw74xq8kxr?token=fb6kpjz5rcr2vttyjs4rcv6y'
-      operationId: get-invoices-uid-.json
+      operationId: readInvoice
       description: Use this endpoint to retrieve the details for an invoice.
   /invoices/events.json:
     get:
@@ -9846,7 +9846,7 @@ paths:
                     page: 48
                     per_page: 1
                     total_pages: 102
-      operationId: get-invoices-events.json
+      operationId: readInvoiceEvents
       description: |-
         This endpoint returns a list of invoice events. Each event contains event "data" (such as an applied payment) as well as a snapshot of the `invoice` at the time of event completion.
 
@@ -10440,7 +10440,7 @@ paths:
                             memo: Refund for overpayment
                             original_amount: '524.9'
                             applied_amount: '200.5'
-      operationId: get-credit_notes.json
+      operationId: readCreditNotes
       description: |-
         Credit Notes are like inverse invoices. They reduce the amount a customer owes.
 
@@ -10729,7 +10729,7 @@ paths:
                         memo: Refund for overpayment
                         original_amount: '524.9'
                         applied_amount: '200.5'
-      operationId: get-credit_notes-uid-.json
+      operationId: readCreditNote
       description: Use this endpoint to retrieve the details for a credit note.
   '/subscriptions/{subscription_id}/payments.json':
     parameters:
@@ -11240,7 +11240,7 @@ paths:
                         refund_amount: '0.0'
                         due_amount: '0.0'
                     public_url: 'https://www.chargifypay.com/invoice/inv_8jzrw74xq8kxr?token=fb6kpjz5rcr2vttyjs4rcv6y'
-      operationId: get-invoices-invoice_uid-segments.json
+      operationId: readConsolidatedInvoiceSegments
       description: 'Invoice segments returned on the index will only include totals, not detailed breakdowns for `line_items`, `discounts`, `taxes`, `credits`, `payments`, or `custom_fields`.'
       parameters:
         - schema:
@@ -11309,7 +11309,7 @@ paths:
                       balance_in_cents:
                         type: integer
                         description: 'The balance, in cents, of the subscription''s Prepayment account.'
-      operationId: get-subscriptions-subscription_id-account_balances.json
+      operationId: readSubscriptionAccountBalances
       description: 'Returns the `balance_in_cents` of the Subscription''s Pending Discount, Service Credit, and Prepayment accounts, as well as the sum of the Subscription''s open, payable invoices.'
   '/subscriptions/{subscription_id}/components/{component_id}.json':
     parameters:
@@ -11355,7 +11355,7 @@ paths:
                       enabled: true
         '404':
           description: Not Found
-      operationId: get-subscriptions-subscription_id-components-component_id-.json
+      operationId: readSubscriptionComponents
       description: This request will list information regarding a specific component owned by a subscription.
   '/subscriptions/{subscription_id}/components.json':
     parameters:
@@ -11403,7 +11403,7 @@ paths:
                         updated_at: string
                         component_handle: string
                         archived_at: string
-      operationId: get-subscriptions-subscription_id-components.json
+      operationId: readSubscriptionAppliedComponents
       description: |-
         This request will list a subscription's applied components.
 
@@ -11842,7 +11842,7 @@ paths:
           description: Not Found
         '422':
           description: Unprocessable Entity (WebDAV)
-      operationId: get-subscriptions-subscription_id-components-component_id-allocations.json
+      operationId: readSubscriptionComponentsAllocations
       description: |-
         This endpoint returns the 50 most recent Allocations, ordered by most recent first.
 
@@ -12570,7 +12570,7 @@ paths:
                         component_id: 500093
                         component_handle: handle
                         subscription_id: 22824464
-      operationId: get-subscriptions-subscription_id-components-component_id-usages.json
+      operationId: readSubscriptionComponentsUsages
       description: |-
         This request will return a list of the usages associated with a subscription for a particular metered component. This will display the previously recorded components for a subscription.
 
@@ -13797,7 +13797,7 @@ paths:
                   properties:
                     subscription:
                       $ref: ../models/Subscription.yaml
-      operationId: get-subscriptions.json
+      operationId: readSiteSubscriptions
       description: |-
         This method will return an array of subscriptions from a Site. Pay close attention to query string filters and pagination in order to control responses from the server.
 
@@ -14221,7 +14221,7 @@ paths:
                             return_url: ''
                             return_params: ''
                             url: 'https://general-goods.chargifypay.com/subscribe/hjpvhnw63tzy'
-      operationId: get-offers.json
+      operationId: readSiteOffers
       description: This endpoint will list offers for a site.
   '/offers/{offer_id}.json':
     parameters:
@@ -14248,7 +14248,7 @@ paths:
               examples: {}
         '401':
           description: Unauthorized
-      operationId: get-offers-offer_id-.json
+      operationId: readOffers
       description: 'This method allows you to list a specific offer''s attributes. This is different than list all offers for a site, as it requires an `offer_id`.'
   '/offers/{offer_id}/archive.json':
     parameters:
@@ -14348,7 +14348,7 @@ paths:
                       subscription_mrr: $200.00
                       sales_rep_id: 48
                       sales_rep_name: John Candy
-      operationId: get-sellers-seller_id-sales_commission_settings.json
+      operationId: readSubscriptionsSalesCommission
       description: |-
         Endpoint returns subscriptions with associated sales reps
 
@@ -14527,7 +14527,7 @@ paths:
                           usage: $0.00
                           recurring: $200.00
                       test_mode: true
-      operationId: get-sellers-seller_id-sales_reps.json
+      operationId: readSalesRepDetails
       description: |-
         Endpoint returns sales rep list with details
 
@@ -14644,7 +14644,7 @@ paths:
                         recurring: $200.00
                         last_payment: '2020-04-17T08:41:03-04:00'
                         churn_date: null
-      operationId: get-sellers-seller_id-sales_reps-sales_rep_id-.json
+      operationId: readSalesRepSubscriptions
       description: |-
         Endpoint returns sales rep and attached subscriptions details.
 
@@ -15528,7 +15528,7 @@ paths:
                       stored_credential_transaction_id: 166411599220288
                       on_hold_at: null
                       scheduled_cancellation_at: '2016-11-14T14:48:13-05:00'
-      operationId: get-subscriptions-subscription_id-.json
+      operationId: readSubscription
       description: |-
         Use this endpoint to find subscription details.
 
@@ -17673,7 +17673,7 @@ paths:
       summary: List Prepayments
       tags:
         - Subscription Invoice Account
-      operationId: get-subscriptions-subscription_id-prepayments.json
+      operationId: readSubscriptionPrepayments
       responses:
         '200':
           description: OK
@@ -18597,7 +18597,7 @@ paths:
                     meta:
                       current_page: 1
                       total_count: 1
-      operationId: get-subscription_groups.json
+      operationId: readSiteSubscriptionGroups
       description: |-
         Returns an array of subscription groups for the site. The response is paginated and will return a `meta` key with pagination information.
 
@@ -18726,7 +18726,7 @@ paths:
                         balance_in_cents: 4400
                       pending_discounts:
                         balance_in_cents: 0
-      operationId: get-subscription_groups-uid-.json
+      operationId: readSubscriptionGroup
       description: |-
         Use this endpoint to find subscription group details.
 
@@ -18965,7 +18965,7 @@ paths:
                         balance_in_cents: 0
         '404':
           description: Not Found
-      operationId: get-subscription_groups-lookup.json
+      operationId: readSubscriptionGroupBySubscription
       description: |-
         Use this endpoint to find subscription group associated with subscription.
 
@@ -19471,7 +19471,7 @@ paths:
                 properties:
                   subscription:
                     $ref: ../models/Subscription.yaml
-      operationId: get-subscriptions-lookup.json
+      operationId: readSubscriptionByReference
       parameters:
         - schema:
             type: string
@@ -20104,7 +20104,7 @@ paths:
                       current_page: 1
                       total_pages: 1
                       per_page: 10
-      operationId: get-chargify_js_keys.json
+      operationId: readChargifyJsKey
       description: This endpoint returns public keys used for Chargify.js.
       parameters:
         - schema:
@@ -20163,7 +20163,7 @@ paths:
       summary: List Subscription Group Proforma Invoices
       tags:
         - Proforma Invoices
-      operationId: get-subscription_groups-subscription_group_uid-proforma_invoices.json
+      operationId: readSubscriptionGroupProformaInvoices
       responses:
         '200':
           description: OK
@@ -20191,7 +20191,7 @@ paths:
       summary: Read Proforma Invoice
       tags:
         - Proforma Invoices
-      operationId: get-proforma_invoices-proforma_invoice_uid-.json
+      operationId: readProformaInvoice
       description: |-
         Use this endpoint to read the details of an existing proforma invoice.
 
@@ -20534,7 +20534,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Proforma-Invoice'
-      operationId: get-subscriptions-subscription_id-proforma_invoices.json
+      operationId: readSubscriptionProformaInvoices
       description: 'By default, proforma invoices returned on the index will only include totals, not detailed breakdowns for `line_items`, `discounts`, `taxes`, `credits`, `payments`, or `custom_fields`. To include breakdowns, pass the specific field as a key in the query with a value set to `true`.'
       parameters:
         - schema:
@@ -21254,7 +21254,7 @@ paths:
                 x-examples:
                   example-1:
                     errors: Chargify token not found
-      operationId: get-one_time_tokens.json
+      operationId: readOneTimeToken
       x-internal: false
       description: |-
         One Time Tokens aka Chargify Tokens house the credit card or ACH (Authorize.Net or Stripe only) data for a customer.
@@ -21285,7 +21285,7 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/Subscriptions-Component'
-      operationId: get-subscriptions_components
+      operationId: readSiteSubscriptionComponents
       description: This request will list components applied to each subscription.
       parameters:
         - schema:
@@ -21633,7 +21633,7 @@ paths:
         description: ID or Handle for the Price Point belonging to the Component
     get:
       summary: List Segments for a Price Point
-      operationId: get-components-component_id-price_points-price_point_id-segments.json
+      operationId: readComponentPricePointSegments
       responses:
         '200':
           description: OK
@@ -22473,7 +22473,7 @@ paths:
           description: Forbidden
         '404':
           description: Not Found
-      operationId: get-subscriptions-subscription_id-advance_invoice.json
+      operationId: readSubscriptionUpcomingRenewalAdvanceInvoice
       description: 'Once an advance invoice has been generated for a subscription''s upcoming renewal, it can be viewed through this endpoint. There can only be one advance invoice per subscription per billing cycle.'
   '/subscriptions/{subscription_id}/advance_invoice/void.json':
     parameters:
@@ -22585,7 +22585,7 @@ paths:
                     errors:
                       at_time:
                         - 'supplied value is invalid, expected ISO 8601 format'
-      operationId: get-subscriptions_mrr.json
+      operationId: readSubscriptionLegacyMrr
       description: 'This endpoint returns your site''s current MRR, including plan and usage breakouts split per subscription.'
       parameters:
         - schema:
@@ -22825,7 +22825,7 @@ paths:
                         use_site_exchange_rate: true
                         tax_code: string
                         default_product_price_point_id: 0
-      operationId: get-products.json
+      operationId: readSiteProducts
       description: This method allows to retrieve a list of Products belonging to a Site.
       parameters:
         - schema:
@@ -23030,7 +23030,7 @@ paths:
                   value:
                     errors:
                       - 'start_date supplied value is invalid, expected ISO 8601 format'
-      operationId: get-components_price_points.json
+      operationId: readSiteComponentPricePoints
       description: This method allows to retrieve a list of Components Price Points belonging to a Site.
       parameters:
         - schema:
@@ -23178,7 +23178,7 @@ paths:
                     errors:
                       - 'date_field must be one of: created_at, updated_at'
                       - 'start_date supplied value is invalid, expected ISO 8601 format'
-      operationId: get-products_price_points.json
+      operationId: readSiteProductPricePoints
       description: This method allows retrieval of a list of Products Price Points belonging to a Site.
       parameters:
         - schema:
@@ -23599,7 +23599,7 @@ paths:
       summary: List Exported Proforma Invoices
       tags:
         - API Exports
-      operationId: get-api_exports-proforma_invoices-id-rows.json
+      operationId: readProformaInvoicesRowsExport
       description: |-
         This API returns an array of exported proforma invoices for a provided `batch_id`. Pay close attention to pagination in order to control responses from the server.
 
@@ -23640,7 +23640,7 @@ paths:
       summary: List Exported Invoices
       tags:
         - API Exports
-      operationId: get-api_exports-invoices-id-rows.json
+      operationId: readInvoicesRowsExport
       description: |-
         This API returns an array of exported invoices for a provided `batch_id`. Pay close attention to pagination in order to control responses from the server.
 
@@ -23681,7 +23681,7 @@ paths:
       summary: List Exported Subscriptions
       tags:
         - API Exports
-      operationId: get-api_exports-subscriptions-id-rows.json
+      operationId: readSubscriptionExport
       description: |-
         This API returns an array of exported subscriptions for a provided `batch_id`. Pay close attention to pagination in order to control responses from the server.
 
@@ -23805,7 +23805,7 @@ paths:
       summary: Read Proforma Invoices Export
       tags:
         - API Exports
-      operationId: get-api_exports-proforma_invoices-id.json
+      operationId: readProformaInvoicesExport
       description: This API returns a batchjob object for proforma invoices export.
       responses:
         '200':
@@ -23827,7 +23827,7 @@ paths:
       summary: Read Invoices Export
       tags:
         - API Exports
-      operationId: get-api_exports_invoices-id.json
+      operationId: readInvoicesExport
       description: This API returns a batchjob object for invoices export.
       responses:
         '200':
@@ -23849,7 +23849,7 @@ paths:
       summary: Read Subscriptions Export
       tags:
         - API Exports
-      operationId: get-api_exports-subscriptions-id.json
+      operationId: readSubscriptionsExport
       description: This API returns a batchjob object for subscriptions export.
       responses:
         '200':

--- a/reference/Chargify-API.v1.yaml
+++ b/reference/Chargify-API.v1.yaml
@@ -386,7 +386,7 @@ paths:
                         body: 'id=141765008&event=payment_success&payload[site][id]=31615&payload[site][subdomain]=general-goods&payload[subscription][id]=15100141&payload[subscription][state]=active&payload[subscription][trial_started_at]=&payload[subscription][trial_ended_at]=&payload[subscription][activated_at]=2016-11-04%2017%3A06%3A43%20-0400&payload[subscription][created_at]=2016-11-04%2017%3A06%3A42%20-0400&payload[subscription][updated_at]=2016-11-08%2016%3A22%3A22%20-0500&payload[subscription][expires_at]=&payload[subscription][balance_in_cents]=0&payload[subscription][current_period_ends_at]=2016-11-09%2016%3A06%3A42%20-0500&payload[subscription][next_assessment_at]=2016-11-09%2016%3A06%3A42%20-0500&payload[subscription][canceled_at]=&payload[subscription][cancellation_message]=&payload[subscription][next_product_id]=&payload[subscription][cancel_at_end_of_period]=false&payload[subscription][payment_collection_method]=automatic&payload[subscription][snap_day]=&payload[subscription][cancellation_method]=&payload[subscription][current_period_started_at]=2016-11-08%2016%3A06%3A42%20-0500&payload[subscription][previous_state]=active&payload[subscription][signup_payment_id]=161034048&payload[subscription][signup_revenue]=64.00&payload[subscription][delayed_cancel_at]=&payload[subscription][coupon_code]=&payload[subscription][total_revenue_in_cents]=32000&payload[subscription][product_price_in_cents]=1000&payload[subscription][product_version_number]=7&payload[subscription][payment_type]=credit_card&payload[subscription][referral_code]=pggn84&payload[subscription][coupon_use_count]=&payload[subscription][coupon_uses_allowed]=&payload[subscription][customer][id]=14585695&payload[subscription][customer][first_name]=Test&payload[subscription][customer][last_name]=Test&payload[subscription][customer][organization]=&payload[subscription][customer][email]=pookie999%40example.com&payload[subscription][customer][created_at]=2016-11-04%2017%3A06%3A42%20-0400&payload[subscription][customer][updated_at]=2016-11-04%2017%3A06%3A45%20-0400&payload[subscription][customer][reference]=&payload[subscription][customer][address]=&payload[subscription][customer][address_2]=&payload[subscription][customer][city]=&payload[subscription][customer][state]=&payload[subscription][customer][zip]=&payload[subscription][customer][country]=&payload[subscription][customer][phone]=&payload[subscription][customer][portal_invite_last_sent_at]=2016-11-04%2017%3A06%3A45%20-0400&payload[subscription][customer][portal_invite_last_accepted_at]=&payload[subscription][customer][verified]=false&payload[subscription][customer][portal_customer_created_at]=2016-11-04%2017%3A06%3A45%20-0400&payload[subscription][customer][cc_emails]=&payload[subscription][product][id]=3792003&payload[subscription][product][name]=%2410%20Basic%20Plan&payload[subscription][product][handle]=basic&payload[subscription][product][description]=lorem%20ipsum&payload[subscription][product][accounting_code]=basic&payload[subscription][product][request_credit_card]=false&payload[subscription][product][expiration_interval]=&payload[subscription][product][expiration_interval_unit]=never&payload[subscription][product][created_at]=2016-03-24%2013%3A38%3A39%20-0400&payload[subscription][product][updated_at]=2016-11-03%2013%3A03%3A05%20-0400&payload[subscription][product][price_in_cents]=1000&payload[subscription][product][interval]=1&payload[subscription][product][interval_unit]=day&payload[subscription][product][initial_charge_in_cents]=&payload[subscription][product][trial_price_in_cents]=&payload[subscription][product][trial_interval]=&payload[subscription][product][trial_interval_unit]=month&payload[subscription][product][archived_at]=&payload[subscription][product][require_credit_card]=false&payload[subscription][product][return_params]=&payload[subscription][product][taxable]=false&payload[subscription][product][update_return_url]=&payload[subscription][product][initial_charge_after_trial]=false&payload[subscription][product][version_number]=7&payload[subscription][product][update_return_params]=&payload[subscription][product][product_family][id]=527890&payload[subscription][product][product_family][name]=Acme%20Projects&payload[subscription][product][product_family][description]=&payload[subscription][product][product_family][handle]=billing-plans&payload[subscription][product][product_family][accounting_code]=&payload[subscription][product][public_signup_pages][id]=281054&payload[subscription][product][public_signup_pages][return_url]=http%3A%2F%2Fwww.example.com%3Fsuccessfulsignup&payload[subscription][product][public_signup_pages][return_params]=&payload[subscription][product][public_signup_pages][url]=https%3A%2F%2Fgeneral-goods.chargify.com%2Fsubscribe%2Fkqvmfrbgd89q%2Fbasic&payload[subscription][product][public_signup_pages][id]=281240&payload[subscription][product][public_signup_pages][return_url]=&payload[subscription][product][public_signup_pages][return_params]=&payload[subscription][product][public_signup_pages][url]=https%3A%2F%2Fgeneral-goods.chargify.com%2Fsubscribe%2Fdkffht5dxfd8%2Fbasic&payload[subscription][product][public_signup_pages][id]=282694&payload[subscription][product][public_signup_pages][return_url]=&payload[subscription][product][public_signup_pages][return_params]=&payload[subscription][product][public_signup_pages][url]=https%3A%2F%2Fgeneral-goods.chargify.com%2Fsubscribe%2Fjwffwgdd95s8%2Fbasic&payload[subscription][credit_card][id]=10102821&payload[subscription][credit_card][first_name]=Pookie&payload[subscription][credit_card][last_name]=Test&payload[subscription][credit_card][masked_card_number]=XXXX-XXXX-XXXX-1&payload[subscription][credit_card][card_type]=bogus&payload[subscription][credit_card][expiration_month]=10&payload[subscription][credit_card][expiration_year]=2020&payload[subscription][credit_card][customer_id]=14585695&payload[subscription][credit_card][current_vault]=bogus&payload[subscription][credit_card][vault_token]=1&payload[subscription][credit_card][billing_address]=&payload[subscription][credit_card][billing_city]=&payload[subscription][credit_card][billing_state]=&payload[subscription][credit_card][billing_zip]=&payload[subscription][credit_card][billing_country]=&payload[subscription][credit_card][customer_vault_token]=&payload[subscription][credit_card][billing_address_2]=&payload[subscription][credit_card][payment_type]=credit_card&payload[subscription][credit_card][site_gateway_setting_id]=&payload[subscription][credit_card][gateway_handle]=&payload[transaction][id]=161537369&payload[transaction][subscription_id]=15100141&payload[transaction][type]=Payment&payload[transaction][kind]=&payload[transaction][transaction_type]=payment&payload[transaction][success]=true&payload[transaction][amount_in_cents]=6400&payload[transaction][memo]=Pookie%20Test%20-%20%2410%20Basic%20Plan%3A%20Renewal%20payment&payload[transaction][created_at]=2016-11-08%2016%3A22%3A20%20-0500&payload[transaction][starting_balance_in_cents]=6400&payload[transaction][ending_balance_in_cents]=0&payload[transaction][gateway_used]=bogus&payload[transaction][gateway_transaction_id]=53433&payload[transaction][gateway_response_code]=&payload[transaction][gateway_order_id]=&payload[transaction][payment_id]=&payload[transaction][product_id]=3792003&payload[transaction][tax_id]=&payload[transaction][component_id]=&payload[transaction][statement_id]=80168049&payload[transaction][customer_id]=14585695&payload[transaction][card_number]=XXXX-XXXX-XXXX-1&payload[transaction][card_expiration]=10%2F2020&payload[transaction][card_type]=bogus&payload[transaction][refunded_amount_in_cents]=0&payload[transaction][invoice_id]=&payload[event_id]=347299364'
                         signature: fbcf2f6be579f9658cff90c4373e0ca2
                         signature_hmac_sha_256: db96654f5456c5460062feb944ac8bb1418f9d181ae04a8ed982fe9ffdca8de1
-      operationId: readWebhooks
+      operationId: listWebhooks
       description: |-
         ## Webhooks Intro
 
@@ -625,7 +625,7 @@ paths:
                         - payment_success
                         - payment_failure
                         - refund_failure
-      operationId: readWebhookEndpoints
+      operationId: listWebhookEndpoints
       description: This method returns created endpoints for site.
   '/endpoints/{endpoint_id}.json':
     parameters:
@@ -879,7 +879,7 @@ paths:
                         sticky: false
                         subscription_id: 100046
                         updated_at: '2015-06-15T13:26:33-04:00'
-      operationId: readSubscriptionNotes
+      operationId: listSubscriptionNotes
       description: Use this method to retrieve a list of Notes associated with a Subscription. The response will be an array of Notes.
       parameters:
         - schema:
@@ -1176,7 +1176,7 @@ paths:
                         portal_invite_last_accepted_at: null
                         tax_exempt: false
                         parent_id: null
-      operationId: readCustomers
+      operationId: listCustomers
       description: |-
         This request will by default list all customers associated with your Site.
 
@@ -1399,7 +1399,7 @@ paths:
                 type: array
                 items:
                   $ref: ../models/Subscription.yaml
-      operationId: readSubscriptionsByCustomer
+      operationId: listSubscriptionsByCustomer
       description: This method lists all subscriptions that belong to a customer.
   '/portal/customers/{customer_id}/enable.json':
     parameters:
@@ -1878,7 +1878,7 @@ paths:
       summary: List Reason Codes
       tags:
         - Reason Codes
-      operationId: readReasonCodes
+      operationId: listReasonCodes
       responses:
         '200':
           description: OK
@@ -2162,7 +2162,7 @@ paths:
                         data_count: 0
                         input_type: string
                         enum: null
-      operationId: readSiteMetafields
+      operationId: listSiteMetafields
       description: This endpoint lists metafields associated with a site. The metafield description and usage is contained in the response.
       parameters:
         - schema:
@@ -2459,7 +2459,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Paginated-Metadata'
-      operationId: readResourceMetadataFields
+      operationId: listResourceMetadataFields
       description: |-
         This method will provide you information on usage of metadata across your selected resource (ie. subscriptions, customers)
 
@@ -2722,7 +2722,7 @@ paths:
                             name: test
                             handle: null
                         use_site_exchange_rate: true
-      operationId: readProductFamilyCoupons
+      operationId: listProductFamilyCoupons
       description: |-
         List coupons for a specific Product Family in a Site.
 
@@ -3067,7 +3067,7 @@ paths:
                             item_id: 0
                             name: string
                             handle: string
-      operationId: readCoupons
+      operationId: listCoupons
       description: |-
         You can retrieve a list of coupons.
 
@@ -3509,7 +3509,7 @@ paths:
       summary: List Coupon Subcodes
       tags:
         - Coupons
-      operationId: readCouponSubcodes
+      operationId: listCouponSubcodes
       responses:
         '200':
           description: OK
@@ -3789,7 +3789,7 @@ paths:
               schema:
                 type: array
                 items: {}
-      operationId: readSiteEventActivity
+      operationId: listSiteEventActivity
       description: |-
         ## Events Intro
 
@@ -3997,7 +3997,7 @@ paths:
                         subscription_id: 14900541
                         created_at: '2016-11-01T12:41:25-04:00'
                         event_specific_data: null
-      operationId: readSubscriptionEventActivity
+      operationId: listSubscriptionEventActivity
       description: |-
         The following request will return a list of events for a subscription.
 
@@ -5298,7 +5298,7 @@ paths:
                         default_price_point_name: Original
                         product_family_name: Chargify
                         use_site_exchange_rate: true
-      operationId: readComponents
+      operationId: listComponents
       parameters:
         - schema:
             type: string
@@ -5487,7 +5487,7 @@ paths:
                         default_price_point_name: Original
                         product_family_name: Chargify
                         use_site_exchange_rate: true
-      operationId: readComponentsByProductFamily
+      operationId: listComponentsByProductFamily
       description: This request will return a list of components for a particular product family.
       parameters:
         - schema:
@@ -5678,7 +5678,7 @@ paths:
                             starting_quantity: 1
                             ending_quantity: null
                             unit_price: '4.0'
-      operationId: readComponentPrices
+      operationId: listComponentPrices
       description: |-
         Use this endpoint to read current price points that are associated with a component.
 
@@ -6349,7 +6349,7 @@ paths:
                     tax_code: D0000000
     get:
       summary: List Products for Product Family
-      operationId: readProductsByFamily
+      operationId: listProductsByFamily
       responses:
         '200':
           description: OK
@@ -6893,7 +6893,7 @@ paths:
                         accounting_code: null
                         created_at: '2014-04-16T12:41:13-06:00'
                         updated_at: '2014-04-16T12:41:13-06:00'
-      operationId: readProductFamilies
+      operationId: listProductFamilies
       description: This method allows to retrieve a list of Product Families for a site.
       parameters:
         - schema:
@@ -7069,7 +7069,7 @@ paths:
                         archived_at: 'Tue, 30 Oct 2018 18:49:47 EDT -04:00'
                         created_at: 'Tue, 23 Oct 2018 18:49:47 EDT -04:00'
                         updated_at: 'Tue, 23 Oct 2018 18:49:47 EDT -04:00'
-      operationId: readProductPricePoints
+      operationId: listProductPricePoints
       parameters:
         - schema:
             type: integer
@@ -8265,7 +8265,7 @@ paths:
                         payment_type: bank_account
                         site_gateway_setting_id: 1
                         gateway_handle: null
-      operationId: readPaymentProfiles
+      operationId: listPaymentProfiles
       description: 'This method will return all of the active `payment_profiles` for a Site, or for one Customer within a site.  If no payment profiles are found, this endpoint will return an empty array, not a 404.'
       parameters:
         - schema:
@@ -9211,7 +9211,7 @@ paths:
                         refund_amount: '0.0'
                         due_amount: '0.0'
                     public_url: 'https://www.chargifypay.com/invoice/inv_8jzrw74xq8kxr?token=fb6kpjz5rcr2vttyjs4rcv6y'
-      operationId: readInvoices
+      operationId: listInvoices
       description: 'By default, invoices returned on the index will only include totals, not detailed breakdowns for `line_items`, `discounts`, `taxes`, `credits`, `payments`, `custom_fields`, or `refunds`. To include breakdowns, pass the specific field as a key in the query with a value set to `true`.'
       parameters:
         - schema:
@@ -9846,7 +9846,7 @@ paths:
                     page: 48
                     per_page: 1
                     total_pages: 102
-      operationId: readInvoiceEvents
+      operationId: listInvoiceEvents
       description: |-
         This endpoint returns a list of invoice events. Each event contains event "data" (such as an applied payment) as well as a snapshot of the `invoice` at the time of event completion.
 
@@ -10440,7 +10440,7 @@ paths:
                             memo: Refund for overpayment
                             original_amount: '524.9'
                             applied_amount: '200.5'
-      operationId: readCreditNotes
+      operationId: listCreditNotes
       description: |-
         Credit Notes are like inverse invoices. They reduce the amount a customer owes.
 
@@ -11240,7 +11240,7 @@ paths:
                         refund_amount: '0.0'
                         due_amount: '0.0'
                     public_url: 'https://www.chargifypay.com/invoice/inv_8jzrw74xq8kxr?token=fb6kpjz5rcr2vttyjs4rcv6y'
-      operationId: readConsolidatedInvoiceSegments
+      operationId: listConsolidatedInvoiceSegments
       description: 'Invoice segments returned on the index will only include totals, not detailed breakdowns for `line_items`, `discounts`, `taxes`, `credits`, `payments`, or `custom_fields`.'
       parameters:
         - schema:
@@ -11355,7 +11355,7 @@ paths:
                       enabled: true
         '404':
           description: Not Found
-      operationId: readSubscriptionComponents
+      operationId: listSubscriptionComponents
       description: This request will list information regarding a specific component owned by a subscription.
   '/subscriptions/{subscription_id}/components.json':
     parameters:
@@ -11403,7 +11403,7 @@ paths:
                         updated_at: string
                         component_handle: string
                         archived_at: string
-      operationId: readSubscriptionAppliedComponents
+      operationId: listSubscriptionAppliedComponents
       description: |-
         This request will list a subscription's applied components.
 
@@ -11842,7 +11842,7 @@ paths:
           description: Not Found
         '422':
           description: Unprocessable Entity (WebDAV)
-      operationId: readSubscriptionComponentsAllocations
+      operationId: listSubscriptionComponentsAllocations
       description: |-
         This endpoint returns the 50 most recent Allocations, ordered by most recent first.
 
@@ -12570,7 +12570,7 @@ paths:
                         component_id: 500093
                         component_handle: handle
                         subscription_id: 22824464
-      operationId: readSubscriptionComponentsUsages
+      operationId: listSubscriptionComponentsUsages
       description: |-
         This request will return a list of the usages associated with a subscription for a particular metered component. This will display the previously recorded components for a subscription.
 
@@ -13797,7 +13797,7 @@ paths:
                   properties:
                     subscription:
                       $ref: ../models/Subscription.yaml
-      operationId: readSiteSubscriptions
+      operationId: listSiteSubscriptions
       description: |-
         This method will return an array of subscriptions from a Site. Pay close attention to query string filters and pagination in order to control responses from the server.
 
@@ -14221,7 +14221,7 @@ paths:
                             return_url: ''
                             return_params: ''
                             url: 'https://general-goods.chargifypay.com/subscribe/hjpvhnw63tzy'
-      operationId: readSiteOffers
+      operationId: listSiteOffers
       description: This endpoint will list offers for a site.
   '/offers/{offer_id}.json':
     parameters:
@@ -14348,7 +14348,7 @@ paths:
                       subscription_mrr: $200.00
                       sales_rep_id: 48
                       sales_rep_name: John Candy
-      operationId: readSubscriptionsSalesCommission
+      operationId: listSubscriptionsSalesCommission
       description: |-
         Endpoint returns subscriptions with associated sales reps
 
@@ -14527,7 +14527,7 @@ paths:
                           usage: $0.00
                           recurring: $200.00
                       test_mode: true
-      operationId: readSalesRepDetails
+      operationId: listSalesRepDetails
       description: |-
         Endpoint returns sales rep list with details
 
@@ -17673,7 +17673,7 @@ paths:
       summary: List Prepayments
       tags:
         - Subscription Invoice Account
-      operationId: readSubscriptionPrepayments
+      operationId: listSubscriptionPrepayments
       responses:
         '200':
           description: OK
@@ -18597,7 +18597,7 @@ paths:
                     meta:
                       current_page: 1
                       total_count: 1
-      operationId: readSiteSubscriptionGroups
+      operationId: listSiteSubscriptionGroups
       description: |-
         Returns an array of subscription groups for the site. The response is paginated and will return a `meta` key with pagination information.
 
@@ -20104,7 +20104,7 @@ paths:
                       current_page: 1
                       total_pages: 1
                       per_page: 10
-      operationId: readChargifyJsKey
+      operationId: listChargifyJsKeys
       description: This endpoint returns public keys used for Chargify.js.
       parameters:
         - schema:
@@ -20163,7 +20163,7 @@ paths:
       summary: List Subscription Group Proforma Invoices
       tags:
         - Proforma Invoices
-      operationId: readSubscriptionGroupProformaInvoices
+      operationId: listSubscriptionGroupProformaInvoices
       responses:
         '200':
           description: OK
@@ -20534,7 +20534,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Proforma-Invoice'
-      operationId: readSubscriptionProformaInvoices
+      operationId: listSubscriptionProformaInvoices
       description: 'By default, proforma invoices returned on the index will only include totals, not detailed breakdowns for `line_items`, `discounts`, `taxes`, `credits`, `payments`, or `custom_fields`. To include breakdowns, pass the specific field as a key in the query with a value set to `true`.'
       parameters:
         - schema:
@@ -21285,7 +21285,7 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/Subscriptions-Component'
-      operationId: readSiteSubscriptionComponents
+      operationId: listSiteSubscriptionComponents
       description: This request will list components applied to each subscription.
       parameters:
         - schema:
@@ -21633,7 +21633,7 @@ paths:
         description: ID or Handle for the Price Point belonging to the Component
     get:
       summary: List Segments for a Price Point
-      operationId: readComponentPricePointSegments
+      operationId: listComponentPricePointSegments
       responses:
         '200':
           description: OK
@@ -22825,7 +22825,7 @@ paths:
                         use_site_exchange_rate: true
                         tax_code: string
                         default_product_price_point_id: 0
-      operationId: readSiteProducts
+      operationId: listSiteProducts
       description: This method allows to retrieve a list of Products belonging to a Site.
       parameters:
         - schema:
@@ -23030,7 +23030,7 @@ paths:
                   value:
                     errors:
                       - 'start_date supplied value is invalid, expected ISO 8601 format'
-      operationId: readSiteComponentPricePoints
+      operationId: listSiteComponentPricePoints
       description: This method allows to retrieve a list of Components Price Points belonging to a Site.
       parameters:
         - schema:
@@ -23178,7 +23178,7 @@ paths:
                     errors:
                       - 'date_field must be one of: created_at, updated_at'
                       - 'start_date supplied value is invalid, expected ISO 8601 format'
-      operationId: readSiteProductPricePoints
+      operationId: listSiteProductPricePoints
       description: This method allows retrieval of a list of Products Price Points belonging to a Site.
       parameters:
         - schema:
@@ -23599,7 +23599,7 @@ paths:
       summary: List Exported Proforma Invoices
       tags:
         - API Exports
-      operationId: readProformaInvoicesRowsExport
+      operationId: listProformaInvoicesRowsExport
       description: |-
         This API returns an array of exported proforma invoices for a provided `batch_id`. Pay close attention to pagination in order to control responses from the server.
 
@@ -23640,7 +23640,7 @@ paths:
       summary: List Exported Invoices
       tags:
         - API Exports
-      operationId: readInvoicesRowsExport
+      operationId: listInvoicesRowsExport
       description: |-
         This API returns an array of exported invoices for a provided `batch_id`. Pay close attention to pagination in order to control responses from the server.
 
@@ -23681,7 +23681,7 @@ paths:
       summary: List Exported Subscriptions
       tags:
         - API Exports
-      operationId: readSubscriptionExport
+      operationId: listSubscriptionsExport
       description: |-
         This API returns an array of exported subscriptions for a provided `batch_id`. Pay close attention to pagination in order to control responses from the server.
 

--- a/reference/Chargify-API.v1.yaml
+++ b/reference/Chargify-API.v1.yaml
@@ -503,7 +503,7 @@ paths:
                 Example:
                   value:
                     status: ok
-      operationId: post-webhooks-replay.json
+      operationId: replayWebhooks
       description: |-
         Posting to the replay endpoint does not immediately resend the webhooks. They are added to a queue and will be sent as soon as possible, depending on available system resources.
 
@@ -570,7 +570,7 @@ paths:
                   value:
                     errors:
                       - 'URL: invalid, only http and https supported'
-      operationId: post-endpoints.json
+      operationId: createEndpoint
       description: |-
         The Chargify API allows you to create an endpoint and assign a list of webhooks subscriptions (events) to it.
 
@@ -667,7 +667,7 @@ paths:
                   value:
                     errors:
                       - Event key is not valid - foobar
-      operationId: post-endpoints-endpoint_id-.json
+      operationId: updateEndpoint
       description: |-
         You can update an Endpoint via the API with a PUT request to the resource endpoint.
 
@@ -766,7 +766,7 @@ paths:
       summary: Clear Site Data
       tags:
         - Sites
-      operationId: post-sites-clear_data.json
+      operationId: clearSite
       description: |
         This call is asynchronous and there may be a delay before the site data is fully deleted. If you are clearing site data for an automated test, you will need to build in a delay and/or check that there are no products, etc., in the site before proceeding.
 
@@ -796,7 +796,7 @@ paths:
         description: The Chargify id of the subscription
     post:
       summary: Create Subscription Note
-      operationId: post-subscriptions-subscription_id-notes.json
+      operationId: createSubscriptionNote
       tags:
         - Subscription Notes
       responses:
@@ -1040,7 +1040,7 @@ paths:
                       - 'First name: cannot be blank.'
                       - 'Last name: cannot be blank.'
                       - 'Email address: cannot be blank.'
-      operationId: post-customers.json
+      operationId: createCustomer
       description: |-
         You may create a new Customer at any time, or you may create a Customer at the same time you create a Subscription. The only validation restriction is that you may only create one customer for a given reference value.
 
@@ -1439,7 +1439,7 @@ paths:
                   value:
                     errors:
                       - Portal is already enabled for this customer.
-      operationId: post-portal-customers-customer_id-enable.json
+      operationId: enableCustomerPortalAccess
       description: |-
         ## Billing Portal Documentation
 
@@ -1604,7 +1604,7 @@ paths:
                   value:
                     errors:
                       - 'Too many requests for this customer. You can perform 5 requests within 00:30:00.'
-      operationId: post-portal-customers-customer_id-invitations-invite.json
+      operationId: resendCustomerPortalInvitation
       description: |-
         You can resend a customer's Billing Portal invitation.
 
@@ -1829,7 +1829,7 @@ paths:
                       - 'Code: cannot be blank.'
                       - 'Code: This code is already in use.'
                       - 'Description: cannot be blank.'
-      operationId: post-reason_codes.json
+      operationId: createChurnResonCodes
       description: |-
         # Reason Codes Intro
 
@@ -2060,7 +2060,7 @@ paths:
                       data_count: 0
                       input_type: text
                       enum: null
-      operationId: post-resource_type-metafields.json
+      operationId: createResourceMetafields
       description: |-
         ## Custom Fields: Metafield Intro
 
@@ -2270,7 +2270,7 @@ paths:
       summary: Create Metadata
       tags:
         - Custom Fields
-      operationId: post-resource_type-resource_id-metadata.json
+      operationId: createResourceMetadata
       description: |-
         ## Custom Fields: Metadata Intro
 
@@ -2573,7 +2573,7 @@ paths:
                   value:
                     errors:
                       - Expiration Date cannot be in the past
-      operationId: post-product_families-product_family_id-coupons.json
+      operationId: createProductFamilyCoupon
       description: |-
         ## Coupons Documentation
 
@@ -3446,7 +3446,7 @@ paths:
                       - DETROITFALL
                     duplicate_codes: []
                     invalid_codes: []
-      operationId: post-coupons-coupon_id-codes.json
+      operationId: createCouponSubcodes
       description: |-
         ## Coupon Subcodes Intro
 
@@ -4405,7 +4405,7 @@ paths:
                       - 'Unit name: cannot be blank.'
                       - 'Pricing scheme: cannot be blank.'
                       - At least 1 price bracket must be defined
-      operationId: post-product_families-product_family_id-plural_kind-.json
+      operationId: createProductFamilyComponent
       parameters: []
       description: |-
         This request will create a component definition under the specified product family. These component definitions determine what components are named, how they are measured, and how much they cost.
@@ -5569,7 +5569,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Component-Price-Point'
               examples: {}
-      operationId: post-components-component_id-price_points.json
+      operationId: createComponentPricePoint
       description: This endpoint can be used to create a new price point for an existing component.
       requestBody:
         content:
@@ -5771,7 +5771,7 @@ paths:
                             starting_quantity: 1
                             ending_quantity: null
                             unit_price: '4.0'
-      operationId: post-components-component_id-price_points-bulk.json
+      operationId: createComponentPricePoints
       description: Use this endpoint to create multiple component price points in one request.
       requestBody:
         content:
@@ -5997,7 +5997,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Currency-Price'
-      operationId: post-price_points-price_point_id-currency_prices.json
+      operationId: createPricePointCurrency
       description: |-
         This endpoint allows you to create currency prices for a given currency that has been defined on the site level in your settings.
 
@@ -6319,7 +6319,7 @@ paths:
                 properties:
                   product:
                     $ref: ../models/Product.yaml
-      operationId: post-product_families-product_family_id-products.json
+      operationId: createProductFamilyProduct
       description: |-
         Use this method to create a product within your Chargify site.
 
@@ -6834,7 +6834,7 @@ paths:
                       description: Amazing project management tool
                       handle: acme-projects
                       accounting_code: null
-      operationId: post-product_families.json
+      operationId: createProductFamily
       description: |-
         This method will create a Product Family within your Chargify site. Create a Product Family to act as a container for your products, components and coupons.
 
@@ -7004,7 +7004,7 @@ paths:
                       archived_at: 'Tue, 30 Oct 2018 18:49:47 EDT -04:00'
                       created_at: 'Tue, 23 Oct 2018 18:49:47 EDT -04:00'
                       updated_at: 'Tue, 23 Oct 2018 18:49:47 EDT -04:00'
-      operationId: post-products-product_id-price_points.json
+      operationId: createProductPricePoint
       description: '[Product Price Point Documentation](https://chargify.zendesk.com/hc/en-us/articles/4407755824155)'
       requestBody:
         content:
@@ -7407,7 +7407,7 @@ paths:
                         archived_at: 'Tue, 30 Oct 2018 18:49:47 EDT -04:00'
                         created_at: 'Tue, 23 Oct 2018 18:49:47 EDT -04:00'
                         updated_at: 'Tue, 23 Oct 2018 18:49:47 EDT -04:00'
-      operationId: post-products-product_id-price_points-bulk.json
+      operationId: createProductPricePoints
       description: Use this endpoint to create multiple product price points in one request.
       requestBody:
         content:
@@ -7488,7 +7488,7 @@ paths:
                     errors:
                       base:
                         - A baseline price must be defined for this product price point.
-      operationId: post-product_price_points-product_price_point_id-currency_prices.json
+      operationId: createProductCurrencyPrices
       description: |-
         This endpoint allows you to create currency prices for a given currency that has been defined on the site level in your settings.
 
@@ -7695,7 +7695,7 @@ paths:
                       gateway_handle: null
         '404':
           description: Not Found
-      operationId: post-payment_profiles.json
+      operationId: createPaymentProfile
       description: |-
         Use this endpoint to create a payment profile for a customer.
 
@@ -8855,7 +8855,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Invoice'
               examples: {}
-      operationId: post-invoices-uid-refunds.json
+      operationId: refundInvoice
       description: |-
         Refund an invoice, segment, or consolidated invoice.
 
@@ -9922,7 +9922,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Invoice'
-      operationId: post-invoices-uid-payments.json
+      operationId: createInvoicePayment
       description: |-
         This API call should be used when you want to record a payment of a given type against a specific invoice. If you would like to apply a payment across multiple invoices, you can use the Bulk Payment endpoint.
 
@@ -10110,7 +10110,7 @@ paths:
                       - Effective date is invalid or malformed
                       - Effective date must occur in the past
                       - 'Multiple applications associated to a single invoice, please aggregate and send as a single application per invoice.'
-      operationId: post-invoices-payments.json
+      operationId: createExternalInvoicesPayment
       description: |-
         This API call should be used when you want to record an external payment against multiple invoices.
 
@@ -10820,7 +10820,7 @@ paths:
                       - 'Payment amount, details, method, and memo must valid'
                       - Payment amount must be greater than zero
                       - 'If in a group, the Subscription must be the primary'
-      operationId: post-subscriptions-subscription_id-payments.json
+      operationId: createSubscriptionExternalPayment
       description: |-
         Record an external payment made against a subscription that will pay partially or in full one or more invoices.
 
@@ -10902,7 +10902,7 @@ paths:
                   value:
                     errors:
                       - The invoice must be in canceled status to be reopened.
-      operationId: post-invoices-uid-reopen.json
+      operationId: reopenInvoice
       description: |-
         This endpoint allows you to reopen any invoice with the "canceled" status. Invoices enter "canceled" status if they were open at the time the subscription was canceled (whether through dunning or an intentional cancellation).
 
@@ -10957,7 +10957,7 @@ paths:
                   value:
                     errors:
                       - 'Invoice status must be ''open'', ''canceled'', or ''pending'' and non-consolidated to be voided.'
-      operationId: post-invoices-uid-void.json
+      operationId: voidInvoice
       description: This endpoint allows you to void any invoice with the "open" or "canceled" status.  It will also allow voiding of an invoice with the "pending" status if it is not a consolidated invoice.
       requestBody:
         content:
@@ -11506,7 +11506,7 @@ paths:
       summary: Bulk Update Subscription Components' Price Points
       tags:
         - Subscription Components
-      operationId: post-subscriptions-subscription_id-price_points.json
+      operationId: updateSubscriptionComponentsPrices
       description: |-
         Updates the price points on one or more of a subscription's components.
 
@@ -11714,7 +11714,7 @@ paths:
                           handle: ea dolore dolore sunt
                           accounting_code: null
                         public_signup_pages: []
-      operationId: post-subscriptions-subscription_id-price_points-reset.json
+      operationId: resetSubscriptionComponentsDefaultPrices
       description: |-
         Resets all of a subscription's components to use the current default.
 
@@ -11769,7 +11769,7 @@ paths:
                         amout_in_cents: labore in minim ad
                         success: false
                         memo: aliqua
-      operationId: post-subscriptions-subscription_id-components-component_id-allocations.json
+      operationId: createSubscriptionComponentAllocation
       description: "This endpoint creates a new allocation, setting the current allocated quantity for the Component and recording a memo.\n\n**Notice**: Allocations can only be updated for Quantity, On/Off, and Prepaid Components.\n\n## Allocations Documentation\n\nFull documentation on how to record Allocations in the Chargify UI can be located [here](https://maxio-chargify.zendesk.com/hc/en-us/articles/5404527849997). It is focused on how allocations operate within the Chargify UI.It goes into greater detail on how the user interface will react when recording allocations.\n\nThis documentation also goes into greater detail on how proration is taken into consideration when applying component allocations.\n\n## Proration Schemes\n\nChanging the allocated quantity of a component mid-period can result in either a Charge or Credit being applied to the subscription. When creating an allocation via the API, you can pass the `upgrade_charge`, `downgrade_credit`, and `accrue_charge` to be applied.\n\n**Notice:** These proration and accural fields will be ignored for Prepaid Components since this component type always generate charges immediately without proration.\n\nFor background information on prorated components and upgrade/downgrade schemes, see [Setting Component Allocations.](https://maxio-chargify.zendesk.com/hc/en-us/articles/5404527849997#proration-upgrades-vs-downgrades).\nSee the tables below for valid values.\n\n| upgrade_charge | Definition \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_|\n|----------------|-------------------------------------------------------------------|\n| `full` \_ \_ \_ \_ |\_A charge is added for the full price of the component. \_\_\_ \_ \_ \_ \_|\n| `prorated` \_ \_ |\_A charge is added for the prorated price of the component change. |\n| `none` \_ \_ \_ \_ |\_No charge is added. \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ |\n\n| downgrade_credit | Definition \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_|\n|------------------|---------------------------------------------------|\n| `full` \_ \_ \_ \_ \_ |\_A full price credit is added for the amount owed. |\n| `prorated` \_ \_ \_ |\_A prorated credit is added for the amount owed. \_ |\n| `none` \_ \_ \_ \_ \_ |\_No charge is added. \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ |\n\n| accrue_charge | Definition \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_   |\n|---------------|------------------------------------------------------------------------------------------------------------|\n| `true` \_ \_ \_ \_| Attempt to charge the customer at next renewal.                                                            |\n| `false` \_ \_ \_ |\_Attempt to charge the customer right away.\_If it fails, the charge will be accrued until the next renewal. |\n\n### Order of Resolution for upgrade_charge and downgrade_credit\n\n1. Per allocation in API call (within a single allocation of the `allocations` array)\n2. [Component-level default value](https://maxio-chargify.zendesk.com/hc/en-us/articles/5404527849997-Component-Allocations#component-allocations-0-0)\n3. Allocation API call top level (outside of the `allocations` array)\n4. [Site-level default value](https://maxio-chargify.zendesk.com/hc/en-us/articles/5404527849997#proration-schemes)\n\n### Order of Resolution for accrue charge\n\n1. Allocation API call top level (outside of the `allocations` array)\n2. [Site-level default value](https://maxio-chargify.zendesk.com/hc/en-us/articles/5404527849997#proration-schemes)\n\n**NOTE: Proration uses the current price of the component as well as the current tax rates. Changes to either may cause the prorated charge/credit to be wrong.**"
       requestBody:
         content:
@@ -11950,7 +11950,7 @@ paths:
                   value:
                     errors:
                       - 'Quantity: cannot be blank.'
-      operationId: post-subscriptions-subscription_id-allocations.json
+      operationId: createSubscriptionComponentsAllocations
       description: |-
         Creates multiple allocations, setting the current allocated quantity for each of the components and recording a memo. The charges and/or credits that are created will be rolled up into a single total which is used to determine whether this is an upgrade or a downgrade. Be aware of the Order of Resolutions explained below in determining the proration scheme.
 
@@ -12217,7 +12217,7 @@ paths:
                         component_id: 379512
                         'on': base
                         message: Allocations can only be updated for quantity and on/off components.
-      operationId: post-subscriptions-subscription_id-allocations-preview.json
+      operationId: createSubscriptionComponentsAllocationsPreview
       description: |-
         Chargify offers the ability to preview a potential subscription's **quantity-based** or **on/off** component allocation in the middle of the current billing period.  This is useful if you want users to be able to see the effect of a component operation before actually doing it.
 
@@ -12450,7 +12450,7 @@ paths:
                   value:
                     errors:
                       - 'Price point: could not be found.'
-      operationId: post-subscriptions-subscription_id-components-component_id-usages.json
+      operationId: createSubscriptionComponentUsage
       description: |-
         ## Documentation
 
@@ -12642,7 +12642,7 @@ paths:
       responses:
         '200':
           description: OK
-      operationId: post-event_based_billing-subscriptions-subscription_id-components-component_id-activate.json
+      operationId: activateSubscriptionEventBasedComponent
       description: |-
         In order to bill your subscribers on your Events data under the Events-Based Billing feature, the components must be activated for the subscriber.
 
@@ -12672,7 +12672,7 @@ paths:
       responses:
         '200':
           description: OK
-      operationId: post-event_based_billing-subscriptions-subscription_id-components-component_id-deactivate.json
+      operationId: deactivateSubscriptionEventBasedComponent
       description: Use this endpoint to deactivate an event-based component for a single subscription. Deactivating the event-based component causes Chargify to ignore related events at subscription renewal.
   /subscriptions.json:
     post:
@@ -12829,7 +12829,7 @@ paths:
                     errors:
                       - 'Bank routing number: cannot be blank.'
                       - 'Bank account number: cannot be blank. '
-      operationId: post-subscriptions.json
+      operationId: createSubscription
       description: |-
         Full documentation on how subscriptions operate within Chargify can be located under the following topics:
 
@@ -13936,7 +13936,7 @@ paths:
       responses:
         '201':
           description: Created
-      operationId: post-subdomain-events-api_handle-.json
+      operationId: createEventBasedComponentEvent
       description: |-
         ## Documentation
 
@@ -14015,7 +14015,7 @@ paths:
       responses:
         '201':
           description: Created
-      operationId: post-subdomain-events-api_handle-bulk.json
+      operationId: createEventBasedComponentEvents
       description: |-
         Use this endpoint to record a collection of events.
 
@@ -14104,7 +14104,7 @@ paths:
                     errors:
                       components:
                         - 'starting_quantity for an On/Off component can only be ''1'' or ''0'': 24'
-      operationId: post-offers.json
+      operationId: createOffer
       description: |-
         Create an offer within your Chargify site by sending a POST request.
 
@@ -15665,7 +15665,7 @@ paths:
                             return_url: ''
                             return_params: ''
                             url: 'https://general-goods.chargify.com/subscribe/69x825m78v3d/zero-dollar-product'
-      operationId: post-subscriptions-subscription_id-resume.json
+      operationId: resumeSubscription
       description: 'Resume a paused (on-hold) subscription. If the normal next renewal date has not passed, the subscription will return to active and will renew on that date.  Otherwise, it will behave like a reactivation, setting the billing date to ''now'' and charging the subscriber.'
       parameters:
         - schema:
@@ -15814,7 +15814,7 @@ paths:
                   value:
                     errors:
                       - This subscription is not eligible to be put on hold.
-      operationId: post-subscriptions-subscription_id-hold.json
+      operationId: pauseSubscription
       description: |-
         This will place the subscription in the on_hold state and it will not renew.
 
@@ -16510,7 +16510,7 @@ paths:
                       - No credit card was on file for the $200.00 balance
                       - This subscription is not eligible for a prorated migration
                       - Invalid Product
-      operationId: post-subscriptions-subscription_id-migrations.json
+      operationId: createSubscriptionProductMigration
       description: |-
         In order to create a migration, you must pass the `product_id` or `product_handle` in the object when you send a POST request. You may also pass either a `product_price_point_id` or `product_price_point_handle` to choose which price point the subscription is moved to. If no price point identifier is passed the subscription will be moved to the products default price point. The response will be the updated subscription.
 
@@ -16679,7 +16679,7 @@ paths:
                   value:
                     errors:
                       - Subscription must be active
-      operationId: post-subscriptions-subscription_id-migrations-preview.json
+      operationId: createSubscriptionProductMigrationPreview
       description: |-
         ## Previewing a future date
         It is also possible to preview the migration for a date in the future, as long as it's still within the subscription's current billing period, by passing a `proration_date` along with the request (eg: `"proration_date": "2020-12-18T18:25:43.511Z"`).
@@ -16828,7 +16828,7 @@ paths:
                     type: string
         '404':
           description: Not Found
-      operationId: post-subscriptions-subscription_id-delayed_cancel.json
+      operationId: createSubscriptionDelayedCancellation
       description: |-
         Chargify offers the ability to cancel a subscription at the end of the current billing period. This period is set by its current product.
 
@@ -16897,7 +16897,7 @@ paths:
                 properties:
                   subscription:
                     $ref: ../models/Subscription.yaml
-      operationId: post-subscriptions-subscription_id-cancel_dunning.json
+      operationId: createSubscriptionDunningCancellation
       description: 'If a subscription is currently in dunning, the subscription will be set to active and the active Dunner will be resolved.'
   '/subscriptions/{subscription_id}/renewals/preview.json':
     parameters:
@@ -17005,7 +17005,7 @@ paths:
                           component_id: 104
                           component_handle: quantity-component
                           component_name: Quantity Component
-      operationId: post-subscriptions-subscription_id-renewals-preview.json
+      operationId: createSubscriptionRenewalPreview
       description: |-
         The Chargify API allows you to preview a renewal by posting to the renewals endpoint. Renewal Preview is an object representing a subscription’s next assessment. You can retrieve it to see a snapshot of how much your customer will be charged on their next renewal.
 
@@ -17200,7 +17200,7 @@ paths:
                 properties:
                   errors:
                     type: object
-      operationId: post-subscriptions-subscription_id-invoices.json
+      operationId: createSubscriptionAdhocInvoice
       description: |-
         This endpoint will allow you to create an ad hoc invoice.
 
@@ -17617,7 +17617,7 @@ paths:
                       created_at: '2020-07-31T05:52:32-04:00'
                       starting_balance_in_cents: 0
                       ending_balance_in_cents: -10000
-      operationId: post-subscriptions-subscription_id-prepayments.json
+      operationId: createSubscriptionPrepayment
       description: |
         ## Create Prepayment
 
@@ -17772,7 +17772,7 @@ paths:
                     ending_balance_in_cents: 2000
                     entry_type: Credit
                     memo: Credit to group account
-      operationId: post-subscriptions-subscription_id-service_credits.json
+      operationId: issueSubscriptionSeviceCredit
       description: Credit will be added to the subscription in the amount specified in the request body. The credit is subsequently applied to the next generated invoice.
       requestBody:
         content:
@@ -17832,7 +17832,7 @@ paths:
                   value:
                     errors:
                       - Amount cannot exceed current service credit account balance.
-      operationId: post-subscriptions-subscription_id-service_credit_deductions.json
+      operationId: deductSubscriptionServiceCredit
       requestBody:
         content:
           application/json:
@@ -17862,7 +17862,7 @@ paths:
       description: Credit will be removed from the subscription in the amount specified in the request body. The credit amount being deducted must be equal to or less than the current credit balance.
   /subscription_groups/signup.json:
     post:
-      operationId: post-subscription_groups_signup.json
+      operationId: createSubscriptionsInGroup
       summary: Subscription Group Signup
       description: |-
         Create multiple subscriptions at once under the same customer and consolidate them into a subscription group.
@@ -18473,7 +18473,7 @@ paths:
                 Example:
                   value:
                     errors: Subscription is already in group
-      operationId: post-subscription_groups.json
+      operationId: createSubscriptionGroup
       description: Creates a subscription group with given members.
       requestBody:
         content:
@@ -19008,7 +19008,7 @@ paths:
                   value:
                     errors:
                       - One or more subscriptions are not on automatic billing
-      operationId: post-subscription_groups-uid-cancel.json
+      operationId: cancelSubscriptionsInGroup
       description: |-
         This endpoint will immediately cancel all subscriptions within the specified group. The group is identified by it's `uid` passed in the URL. To successfully cancel the group, the primary subscription must be on automatic billing. The group members as well must be on automatic billing or they must be prepaid.
 
@@ -19056,7 +19056,7 @@ paths:
                   value:
                     errors:
                       - Subscriptions group is in a past due state
-      operationId: post-subscription_groups-uid-delayed_cancel.json
+      operationId: createSubscriptionGroupDelayedCancellations
       description: |-
         This endpoint will schedule all subscriptions within the specified group to be canceled at the end of their billing period. The group is identified by it's uid passed in the URL.
 
@@ -19156,7 +19156,7 @@ paths:
                   value:
                     errors:
                       - Must be inside the current billing period to resume this subscription group
-      operationId: post-subscription_groups-subscription_group_uid-reactivate.json
+      operationId: reactivateSubscriptionGroup
       description: |-
         This endpoint will attempt to reactivate or resume a cancelled subscription group. Upon reactivation, any canceled invoices created after the beginning of the primary subscription's billing period will be reopened and payment will be attempted on them. If the subscription group is being reactivated (as opposed to resumed), new charges will also be assessed for the new billing period.
 
@@ -19280,7 +19280,7 @@ paths:
                   value:
                     errors:
                       - Amount must be greater than 0
-      operationId: post-subscription_groups-uid-prepayments.json
+      operationId: createSubscriptionGroupPrepayment
       description: 'A prepayment can be added for a subscription group identified by the group''s `uid`. This endpoint requires a `amount`, `details`, `method`, and `memo`. On success, the prepayment will be added to the group''s prepayment balance.'
       requestBody:
         content:
@@ -19359,7 +19359,7 @@ paths:
                   value:
                     errors:
                       - Amount must be greater than 0
-      operationId: post-subscription_groups-uid-service_credits.json
+      operationId: issueSubscriptionGroupServiceCredits
       description: Credit can be issued for a subscription group identified by the group's `uid`. Credit will be added to the group in the amount specified in the request body. The credit will be applied to group member invoices as they are generated.
       requestBody:
         content:
@@ -19428,7 +19428,7 @@ paths:
                   value:
                     errors:
                       - Amount must be greater than 0
-      operationId: post-subscription_groups-uid-service_credit_deductions.json
+      operationId: deductSubscriptionGroupServiceCredits
       description: Credit can be deducted for a subscription group identified by the group's `uid`. Credit will be deducted from the group in the amount specified in the request body.
       requestBody:
         content:
@@ -19546,7 +19546,7 @@ paths:
                   value:
                     errors:
                       - This is already the current payment profile
-      operationId: post-subscriptions-subscription_id-payment_profiles-payment_profile_id-change_payment_profile.json
+      operationId: updateSubscriptionDefaultPaymentProfile
       description: |-
         This will change the default payment profile on the subscription to the existing payment profile with the id specified.
 
@@ -19619,7 +19619,7 @@ paths:
                   value:
                     errors:
                       - This is already the current payment profile
-      operationId: post-subscription_groups-subscription_group_uid-payment_profiles-payment_profile_id-change_payment_profile.json
+      operationId: updateSubscriptionGroupDefaultPaymentProfile
       description: |-
         This will change the default payment profile on the subscription group to the existing payment profile with the id specified.
 
@@ -19643,7 +19643,7 @@ paths:
           description: OK
         '400':
           description: Bad Request
-      operationId: post-subscriptions-subscription_id-purge.json
+      operationId: purgeSubscription
       description: |-
         For sites in test mode, you may purge individual subscriptions.
 
@@ -19706,7 +19706,7 @@ paths:
                       auto_replenish: true
                       replenish_to_amount_in_cents: 50000
                       replenish_threshold_amount_in_cents: 10000
-      operationId: post-subscriptions-subscription_id-prepaid_configurations.json
+      operationId: createPrepaidSubscription
       description: Use this endpoint to update a subscription's prepaid configuration.
       requestBody:
         content:
@@ -19783,7 +19783,7 @@ paths:
                         - 33060
                         - 32986
                       created_at: '2018-08-30T17:14:30-04:00'
-      operationId: post-subscriptions-subscription_id-group.json
+      operationId: createSubscriptionGroupHierarchy
       description: |
         For sites making use of the [Relationship Billing](https://chargify.zendesk.com/hc/en-us/articles/4407737494171) and [Customer Hierarchy](https://chargify.zendesk.com/hc/en-us/articles/4407746683291) features, it is possible to add existing subscriptions to subscription groups.
 
@@ -19957,7 +19957,7 @@ paths:
                         end_date: '2018-10-21T21:25:21Z'
                         period_type: recurring
                         existing_balance_in_cents: 0
-      operationId: post-subscriptions-preview.json
+      operationId: createSubscriptionPreview
       description: |-
         The Chargify API allows you to preview a subscription by POSTing the same JSON or XML as for a subscription creation.
 
@@ -20150,7 +20150,7 @@ paths:
                   value:
                     errors:
                       - Consolidated proforma invoice generation already in progress
-      operationId: post-subscription_groups-subscription_group_uid-proforma_invoices.json
+      operationId: createSubscriptionProformaInvoice
       description: |-
         This endpoint will trigger the creation of a consolidated proforma invoice asynchronously. It will return a 201 with no message, or a 422 with any errors. To find and view the new consolidated proforma invoice, you may poll the subscription group listing for proforma invoices; only one consolidated proforma invoice may be created per group at a time.
 
@@ -20395,7 +20395,7 @@ paths:
                       - 'Coupon Codes: ''COUPONB'' - That coupon is not stackable'
                     subscription:
                       - Coupon is invalid.
-      operationId: post-subscriptions-subscription_id-add_coupon.json
+      operationId: applySubscriptionCouponCodes
       description: |-
         An existing subscription can accommodate multiple discounts/coupon codes. This is only applicable if each coupon is stackable. For more information on stackable coupons, we recommend reviewing our [coupon documentation.](https://chargify.zendesk.com/hc/en-us/articles/4407755909531#stackable-coupons)
 
@@ -20512,7 +20512,7 @@ paths:
                   value:
                     errors:
                       - this subscription is not eligible to create proforma invoices
-      operationId: post-subscriptions-subscription_id-proforma_invoices.json
+      operationId: createSubscriptionProformaInvoice
       description: |-
         This endpoint will create a proforma invoice and return it as a response. If the information becomes outdated, simply void the old proforma invoice and generate a new one.
 
@@ -20655,7 +20655,7 @@ paths:
                     errors:
                       - You must provide a reason for voiding the proforma invoice.
                       - Only draft proforma invoices may be voided.
-      operationId: post-proforma_invoices-proforma_invoice_uid-void.json
+      operationId: voidProformaInvoice
       description: |-
         This endpoint will void a proforma invoice that has the status "draft".
 
@@ -20723,7 +20723,7 @@ paths:
                   example-1:
                     errors:
                       - this subscription is not eligible to create proforma invoices
-      operationId: post-subscriptions-subscription_id-proforma_invoices-preview.json
+      operationId: createSubscriptionProformaInvoicePreview
       description: |-
         Return a preview of the data that will be included on a given subscription's proforma invoice if one were to be generated. It will have similar line items and totals as a renewal preview, but the response will be presented in the format of a proforma invoice. Consequently it will include additional information such as the name and addresses that will appear on the proforma invoice.
 
@@ -20763,7 +20763,7 @@ paths:
                   value:
                     errors:
                       - 'cc_recipient_emails: must be a valid email address'
-      operationId: post-invoices-uid-deliveries.json
+      operationId: deliverInvoiceEmail
       description: |-
         This endpoint allows for invoices to be programmatically delivered via email. This endpoint supports the delivery of both ad-hoc and automatically generated invoices. Additionally, this endpoint supports email delivery to direct recipients, carbon-copy (cc) recipients, and blind carbon-copy (bcc) recipients.
 
@@ -20941,7 +20941,7 @@ paths:
                   value:
                     errors:
                       - Invoice must have an open status
-      operationId: post-invoices-uid-customer_information-preview.json
+      operationId: updateInvoiceCustomerDetails
       description: |-
         Customer information may change after an invoice is issued which may lead to a mismatch between customer information that are present on an open invoice and actual customer information. This endpoint allows to preview these differences, if any.
 
@@ -21541,7 +21541,7 @@ paths:
                         type: array
                         items:
                           type: string
-      operationId: 'post-components-:component_id-price_points-:price_point_id-segments.json'
+      operationId: createComponentPricePointSegment
       requestBody:
         content:
           application/json:
@@ -22106,7 +22106,7 @@ paths:
                         '1':
                           pricing_scheme:
                             - 'Pricing scheme: cannot be blank'
-      operationId: post-components-component_id-price_points-price_point_id-segments-bulk.json
+      operationId: createComponentPricePointSegments
       requestBody:
         content:
           application/json:
@@ -22428,7 +22428,7 @@ paths:
                   value:
                     errors:
                       - Cannot generate an invoice in advance when a subscription uses prepaid components
-      operationId: post-subscriptions-subscription_id-advance_invoice-issue.json
+      operationId: issueSubscriptionInvoiceInAdvance
       description: |
         Generate an invoice in advance for a subscription's next renewal date. [Please see our docs](reference/Chargify-API.v1.yaml/components/schemas/Invoice) for more information on advance invoices, including eligibility on generating one; for the most part, they function like any other invoice, except they are issued early and have special behavior upon being voided.
         A subscription may only have one advance invoice per billing period. Attempting to issue an advance invoice when one already exists will return an error.
@@ -22497,7 +22497,7 @@ paths:
           description: Forbidden
         '404':
           description: Not Found
-      operationId: post-subscriptions-subscription_id-advance_invoice-void.json
+      operationId: voidAdvanceInvoice
       description: |-
         Void a subscription's existing advance invoice. Once voided, it can later be regenerated if desired.
         A `reason` is required in order to void, and the invoice must have an open status. Voiding will cause any prepayments and credits that were applied to the invoice to be returned to the subscription. For a full overview of the impact of voiding, please [see our help docs](reference/Chargify-API.v1.yaml/components/schemas/Invoice).
@@ -22718,7 +22718,7 @@ paths:
                       refund:
                         amount_in_cents:
                           - Refund amount exceeds prepayment amount
-      operationId: post-subscriptions-subscription_id-prepayments-prepayment_id-refunds.json
+      operationId: refundSubscriptionPrepayment
       description: |-
         This endpoint will refund, completely or partially, a particular prepayment applied to a subscription. The `prepayment_id` will be the account transaction ID of the original payment. The prepayment must have some amount remaining in order to be refunded.
 
@@ -22941,7 +22941,7 @@ paths:
                       type: string
                 required:
                   - errors
-      operationId: post-invoices-uid-issue.json
+      operationId: issueInvoice
       requestBody:
         content:
           application/json:
@@ -23439,7 +23439,7 @@ paths:
                     errors:
                       base:
                         - currency must be a string
-      operationId: post-subscriptions-proforma_invoices
+      operationId: createSubscriptionSignupProformaInvoice
       description: |-
         This endpoint is only available for Relationship Invoicing sites. It cannot be used to create consolidated proforma invoices or preview prepaid subscriptions.
 
@@ -23553,7 +23553,7 @@ paths:
                     errors:
                       base:
                         - organization must be a string
-      operationId: post-subscriptions-proforma_invoices-preview.json
+      operationId: createSubscriptionSignupProformaPreview
       description: |-
         This endpoint is only available for Relationship Invoicing sites. It cannot be used to create consolidated proforma invoice previews or preview prepaid subscriptions.
 
@@ -23716,7 +23716,7 @@ paths:
       summary: Create Proforma Invoices Export
       tags:
         - API Exports
-      operationId: post-api_exports-proforma_invoices.json
+      operationId: createProformaInvoicesExport
       description: |-
         This API creates a proforma invoices export and returns a batchjob object.
 
@@ -23749,7 +23749,7 @@ paths:
       summary: Create Invoices Export
       tags:
         - API Exports
-      operationId: post-api_exports-invoices.json
+      operationId: createInvoicesExport
       description: This API creates an invoices export and returns a batchjob object.
       responses:
         '201':
@@ -23775,7 +23775,7 @@ paths:
       summary: Create Subscriptions Export
       tags:
         - API Exports
-      operationId: post-api_exports-subscriptions.json
+      operationId: createSubscriptionsExport
       description: This API creates a subscriptions export and returns a batchjob object.
       responses:
         '201':
@@ -23896,7 +23896,7 @@ paths:
                   value:
                     errors:
                       - 'Too many requests. You can perform 5 requests within 00:30:00'
-      operationId: post-subscriptions-subscription_id-request_payment_profiles_update.json
+      operationId: sendRequestUpdatePaymentEmail
       description: |-
         You can send a "request payment update" email to the customer associated with the subscription.
 

--- a/reference/Chargify-API.v1.yaml
+++ b/reference/Chargify-API.v1.yaml
@@ -23033,7 +23033,7 @@ paths:
                   value:
                     errors:
                       - 'start_date supplied value is invalid, expected ISO 8601 format'
-      operationId: listComponentPricePoints
+      operationId: listAllComponentPricePoints
       description: This method allows to retrieve a list of Components Price Points belonging to a Site.
       parameters:
         - schema:
@@ -23181,7 +23181,7 @@ paths:
                     errors:
                       - 'date_field must be one of: created_at, updated_at'
                       - 'start_date supplied value is invalid, expected ISO 8601 format'
-      operationId: listProductPricePoints
+      operationId: listAllProductPricePoints
       description: This method allows retrieval of a list of Products Price Points belonging to a Site.
       parameters:
         - schema:

--- a/reference/Chargify-API.v1.yaml
+++ b/reference/Chargify-API.v1.yaml
@@ -467,7 +467,7 @@ paths:
                 Example:
                   value:
                     webhooks_enabled: true
-      operationId: put-webhooks-settings.json
+      operationId: enableWebhooks
       description: This method allows you to enable webhooks via API for your site
       requestBody:
         content:
@@ -938,7 +938,7 @@ paths:
       summary: Update Subscription Note
       tags:
         - Subscription Notes
-      operationId: put-subscriptions-subscription_id-notes-note_id-.json
+      operationId: updateSubscriptionNote
       responses:
         '200':
           description: OK
@@ -1277,7 +1277,7 @@ paths:
       summary: Update Customer
       tags:
         - Customers
-      operationId: put-customers-id-.json
+      operationId: updateCustomer
       responses:
         '200':
           description: OK
@@ -1971,7 +1971,7 @@ paths:
                     $ref: '#/components/schemas/Reason-Code'
         '404':
           description: Not Found
-      operationId: put-reason_codes-reason_code_id-.json
+      operationId: updateReasonCode
       requestBody:
         content:
           application/json:
@@ -2204,7 +2204,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Metafield'
-      operationId: put-resource_type-metafields.json
+      operationId: updateResourceMetafield
       description: Use the following method to update metafields for your Site. Metafields can be populated with metadata after the fact.
       requestBody:
         content:
@@ -2376,7 +2376,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Metadata'
-      operationId: put-resource_type-resource_id-metadata.json
+      operationId: updateResourceMetadata
       parameters:
         - schema:
             type: string
@@ -2935,7 +2935,7 @@ paths:
                       stackable: true
                       compounding_strategy: compound
                       coupon_restrictions: []
-      operationId: put-product_families-product_family_id-coupons-coupon_id-.json
+      operationId: updateCoupon
       description: |-
         ## Update Coupon
 
@@ -3369,7 +3369,7 @@ paths:
                       type: integer
                     coupon_id:
                       type: integer
-      operationId: put-coupon-coupon_id-currency_prices.json
+      operationId: updateCouponCurrencyPrices
       description: |-
         This endpoint allows you to create and/or update currency prices for an existing coupon. Multiple prices can be created or updated in a single request but each of the currencies must be defined on the site level already and the coupon must be an amount-based coupon, not percentage.
 
@@ -3564,7 +3564,7 @@ paths:
       summary: Update Coupon Subcodes
       tags:
         - Coupons
-      operationId: put-coupons-coupon_id-codes.json
+      operationId: updateCouponSubcodes
       responses:
         '200':
           description: OK
@@ -5379,7 +5379,7 @@ paths:
       responses:
         '201':
           description: Created
-      operationId: put-components-component_id-price_points-price_point_id-default.json
+      operationId: updateDefaultPricePointForComponent
       description: |-
         Sets a new default price point for the component. This new default will apply to all new subscriptions going forward - existing subscriptions will remain on their current price point.
 
@@ -5834,7 +5834,7 @@ paths:
                 properties:
                   price_point:
                     $ref: '#/components/schemas/Component-Price-Point'
-      operationId: put-components-component_id-price_points-price_point_id-.json
+      operationId: updateComponentPricePoint
       description: |-
         When updating a price point, it's prices can be updated as well by creating new prices or editing / removing existing ones.
 
@@ -5974,7 +5974,7 @@ paths:
                           starting_quantity: 101
                           ending_quantity: null
                           unit_price: '4.0'
-      operationId: put-components-component_id-price_points-price_point_id-unarchive.json
+      operationId: unarchiveComponentPricePoint
       description: Use this endpoint to unarchive a component price point.
   '/price_points/{price_point_id}/currency_prices.json':
     parameters:
@@ -6047,7 +6047,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Currency-Price'
-      operationId: put-price_points-price_point_id-currency_prices.json
+      operationId: updateComponentCurrencyPrices
       description: |-
         This endpoint allows you to update currency prices for a given currency that has been defined on the site level in your settings.
 
@@ -6590,7 +6590,7 @@ paths:
       summary: Update Product
       tags:
         - Products
-      operationId: put-products-product_id-.json
+      operationId: updateProduct
       responses:
         '200':
           description: OK
@@ -7148,7 +7148,7 @@ paths:
                       archived_at: 'Tue, 30 Oct 2018 18:49:47 EDT -04:00'
                       created_at: 'Tue, 23 Oct 2018 18:49:47 EDT -04:00'
                       updated_at: 'Tue, 23 Oct 2018 18:49:47 EDT -04:00'
-      operationId: put-products-product_id-price_points-price_point_id-.json
+      operationId: updateProductPricePoint
       requestBody:
         content:
           application/json:
@@ -7563,7 +7563,7 @@ paths:
                       formatted_price: string
                       product_price_point_id: 0
                       role: baseline
-      operationId: put-product_price_points-product_price_point_id-currency_prices.json
+      operationId: updateCurrencyForProductPrices
       description: |-
         This endpoint allows you to update the `price`s of currency prices for a given currency that exists on the product price point.
 
@@ -8559,7 +8559,7 @@ paths:
                       payment_type: credit_card
                       site_gateway_setting_id: 1
                       gateway_handle: null
-      operationId: put-payment_profiles-payment_profile_id-.json
+      operationId: updatePaymentProfile
       description: |-
         ## Partial Card Updates
 
@@ -8814,7 +8814,7 @@ paths:
                   value:
                     errors:
                       - 'You have tried to verify this bank account 10 times. To continue trying to verify the account, please reach out to us directly.'
-      operationId: put-bank_accounts-bank_account_id-verification.json
+      operationId: updateBankAccountVerification
       description: Submit the two small deposit amounts the customer received in their bank account in order to verify the bank account. (Stripe only)
       requestBody:
         content:
@@ -12303,7 +12303,7 @@ paths:
                     errors:
                       - kind: base
                         message: 'Credit scheme must be one of credit, refund or none.'
-      operationId: put-subscriptions-subscription_id-components-component_id-allocations-allocation_id-.json
+      operationId: updateSubscriptionComponentAllocation
       description: |-
         When the expiration interval options are selected on a prepaid usage component price point, all allocations will be created with an expiration date. This expiration date can be changed after the fact to allow for extending or shortening the allocation's active window.
 
@@ -14267,7 +14267,7 @@ paths:
           description: OK
         '401':
           description: Unauthorized
-      operationId: put-offers-offer_id-archive.json
+      operationId: archiveOffer
       description: Archive an existing offer. Please provide an `offer_id` in order to archive the correct item.
   '/offers/{offer_id}/unarchive.json':
     parameters:
@@ -14286,7 +14286,7 @@ paths:
           description: OK
         '401':
           description: Unauthorized
-      operationId: put-offers-offer_id-unarchive.json
+      operationId: unarchiveOffer
       description: Unarchive a previously archived offer. Please provide an `offer_id` in order to un-archive the correct item.
   '/sellers/{seller_id}/sales_commission_settings.json':
     parameters:
@@ -14837,7 +14837,7 @@ paths:
                 Example:
                   value:
                     errors: []
-      operationId: put-subscriptions-subscription_id-retry.json
+      operationId: retrySubscriptionPayment
       description: |-
         Chargify offers the ability to retry collecting the balance due on a past due Subscription without waiting for the next scheduled attempt.
 
@@ -14986,7 +14986,7 @@ paths:
                     errors:
                       - Payment collection method cannot be set to 'invoice' when the subscription is past due
                       - '''expires_at'' cannot be set for subscriptions on calendar billing'
-      operationId: put-subscriptions-subscription_id-.json
+      operationId: updateSubscription
       description: |-
         The subscription endpoint allows you to instantly update one or many attributes about a subscription in a single call.
 
@@ -15969,7 +15969,7 @@ paths:
                         customer_vault_token: null
                         billing_address_2: ''
                         payment_type: credit_card
-      operationId: put-subscriptions-subscription_id-hold.json
+      operationId: pauseSubscription
       description: |-
         Once a subscription has been paused / put on hold, you can update the date which was specified to automatically resume the subscription.
 
@@ -16140,7 +16140,7 @@ paths:
                       - 'Cannot reactivate a subscription that is not marked "Canceled", "Unpaid", or "Trial Ended".'
                       - 'Request was ''resume only'', but this subscription cannot be resumed.'
                       - The credit card on file could not be charged.
-      operationId: put-subscriptions-subscription_id-reactivate.json
+      operationId: reactivateSubscription
       description: |-
         Chargify offers the ability to reactivate a previously canceled subscription. For details on how the reactivation works, and how to reactivate subscriptions through the application, see [reactivation](https://chargify.zendesk.com/hc/en-us/articles/4407898737691).
 
@@ -16750,7 +16750,7 @@ paths:
           description: Bad Request
         '422':
           description: Unprocessable Entity (WebDAV)
-      operationId: put-subscriptions-subscription_id-override.json
+      operationId: OverrideSubscription
       description: |-
         This API endpoint allows you to set certain subscription fields that are usually managed for you automatically. Some of the fields can be set via the normal Subscriptions Update API, but others can only be set using this endpoint.
 
@@ -18812,7 +18812,7 @@ paths:
                         - id: 10101
                           type: not_found
                           message: Subscription could not be found
-      operationId: put-subscription_groups-uid-.json
+      operationId: updateSubscriptionGroupMembers
       description: |-
         Use this endpoint to update subscription group members.
         `"member_ids": []` should contain an array of both subscription IDs to set as group members and subscription IDs already present in the groups. Not including them will result in removing them from subscription group. To clean up members, just leave the array empty.
@@ -21119,7 +21119,7 @@ paths:
                   value:
                     errors:
                       - Invoice must have an open status
-      operationId: put-invoices-uid-customer_information-preview.json
+      operationId: updateCustomerInformationForOpenInvoice
       description: |-
         This endpoint updates customer information on an open invoice and returns the updated invoice. If you would like to preview changes that will be applied, use the `/invoices/{uid}/customer_information/preview.json` endpoint before.
 
@@ -21903,7 +21903,7 @@ paths:
                         type: array
                         items:
                           type: string
-      operationId: put-components-component_id-price_points-price_point_id-segments-id-.json
+      operationId: updateComponentPricePointSegment
       requestBody:
         content:
           application/json:
@@ -22306,7 +22306,7 @@ paths:
                         '1':
                           pricing_scheme:
                             - 'Pricing scheme: cannot be blank'
-      operationId: put-components-component_id-price_points-price_point_id-segments-bulk.json
+      operationId: updateComponentPricePointSegments
       requestBody:
         content:
           application/json:
@@ -23313,7 +23313,7 @@ paths:
                     errors:
                       base:
                         - Purchase Declined. The subscription is now in the 'awaiting_signup' state.
-      operationId: put-subscriptions-subscription_id-activate.json
+      operationId: activateSubscription
       requestBody:
         content:
           application/json:

--- a/reference/Chargify-API.v1.yaml
+++ b/reference/Chargify-API.v1.yaml
@@ -625,7 +625,7 @@ paths:
                         - payment_success
                         - payment_failure
                         - refund_failure
-      operationId: listWebhookEndpoints
+      operationId: listEndpoints
       description: This method returns created endpoints for site.
   '/endpoints/{endpoint_id}.json':
     parameters:
@@ -1399,7 +1399,7 @@ paths:
                 type: array
                 items:
                   $ref: ../models/Subscription.yaml
-      operationId: listSubscriptionsByCustomer
+      operationId: listCustomerSubscriptions
       description: This method lists all subscriptions that belong to a customer.
   '/portal/customers/{customer_id}/enable.json':
     parameters:
@@ -1439,7 +1439,7 @@ paths:
                   value:
                     errors:
                       - Portal is already enabled for this customer.
-      operationId: enableCustomerPortalAccess
+      operationId: enableBillingPortalForCustomer
       description: |-
         ## Billing Portal Documentation
 
@@ -1540,7 +1540,7 @@ paths:
                   value:
                     errors:
                       error: Too many requests for this customer's management link
-      operationId: readCustomerPortalLink
+      operationId: readBillingPortalLink
       description: |-
         This method will provide to the API user the exact URL required for a subscriber to access the Billing Portal.
 
@@ -1604,7 +1604,7 @@ paths:
                   value:
                     errors:
                       - 'Too many requests for this customer. You can perform 5 requests within 00:30:00.'
-      operationId: resendCustomerPortalInvitation
+      operationId: resendBillingPortalInvitation
       description: |-
         You can resend a customer's Billing Portal invitation.
 
@@ -1653,7 +1653,7 @@ paths:
                     uninvited_count: 8
         '422':
           description: Unprocessable Entity (WebDAV)
-      operationId: revokeCustomerPortalAccess
+      operationId: revokeBillingPortalAccess
       description: |-
         You can revoke a customer's Billing Portal invitation.
 
@@ -1829,7 +1829,7 @@ paths:
                       - 'Code: cannot be blank.'
                       - 'Code: This code is already in use.'
                       - 'Description: cannot be blank.'
-      operationId: createChurnResonCodes
+      operationId: createResonCode
       description: |-
         # Reason Codes Intro
 
@@ -2060,7 +2060,7 @@ paths:
                       data_count: 0
                       input_type: text
                       enum: null
-      operationId: createResourceMetafields
+      operationId: createMetafields
       description: |-
         ## Custom Fields: Metafield Intro
 
@@ -2162,7 +2162,7 @@ paths:
                         data_count: 0
                         input_type: string
                         enum: null
-      operationId: listSiteMetafields
+      operationId: listMetafields
       description: This endpoint lists metafields associated with a site. The metafield description and usage is contained in the response.
       parameters:
         - schema:
@@ -2204,7 +2204,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Metafield'
-      operationId: updateResourceMetafield
+      operationId: updateMetafield
       description: Use the following method to update metafields for your Site. Metafields can be populated with metadata after the fact.
       requestBody:
         content:
@@ -2270,7 +2270,7 @@ paths:
       summary: Create Metadata
       tags:
         - Custom Fields
-      operationId: createResourceMetadata
+      operationId: createMetadata
       description: |-
         ## Custom Fields: Metadata Intro
 
@@ -2376,7 +2376,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Metadata'
-      operationId: updateResourceMetadata
+      operationId: updateMetadata
       parameters:
         - schema:
             type: string
@@ -2408,7 +2408,7 @@ paths:
           description: OK
         '404':
           description: Not Found
-      operationId: deleteResourceMetadata
+      operationId: deleteMetadata
       description: |-
         This method removes the metadata from the subscriber/customer cited.
 
@@ -2459,7 +2459,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Paginated-Metadata'
-      operationId: listResourceMetadataFields
+      operationId: listMetadata
       description: |-
         This method will provide you information on usage of metadata across your selected resource (ie. subscriptions, customers)
 
@@ -2573,7 +2573,7 @@ paths:
                   value:
                     errors:
                       - Expiration Date cannot be in the past
-      operationId: createProductFamilyCoupon
+      operationId: createCoupon
       description: |-
         ## Coupons Documentation
 
@@ -2722,7 +2722,7 @@ paths:
                             name: test
                             handle: null
                         use_site_exchange_rate: true
-      operationId: listProductFamilyCoupons
+      operationId: listCouponsForProductFamily
       description: |-
         List coupons for a specific Product Family in a Site.
 
@@ -3007,7 +3007,7 @@ paths:
                       stackable: true
                       compounding_strategy: compound
                       coupon_restrictions: []
-      operationId: deleteProductFamilyCoupon
+      operationId: archiveCoupon
       description: |-
         You can archive a Coupon via the API with the archive method.
         Archiving makes that Coupon unavailable for future use, but allows it to remain attached and functional on existing Subscriptions that are using it.
@@ -3304,7 +3304,7 @@ paths:
                 Example:
                   value:
                     errors: Coupon code could not be found.
-      operationId: validateCouponCode
+      operationId: validateCoupon
       description: |-
         You can verify if a specific coupon code is valid using the `validate` method. This method is useful for validating coupon codes that are entered by a customer. If the coupon is found and is valid, the coupon will be returned with a 200 status code.
 
@@ -3789,7 +3789,7 @@ paths:
               schema:
                 type: array
                 items: {}
-      operationId: listSiteEventActivity
+      operationId: listEvents
       description: |-
         ## Events Intro
 
@@ -3997,7 +3997,7 @@ paths:
                         subscription_id: 14900541
                         created_at: '2016-11-01T12:41:25-04:00'
                         event_specific_data: null
-      operationId: listSubscriptionEventActivity
+      operationId: listSubscriptionEvents
       description: |-
         The following request will return a list of events for a subscription.
 
@@ -4089,7 +4089,7 @@ paths:
                 Example:
                   value:
                     count: 144
-      operationId: readTotalEventCount
+      operationId: readEventsCount
       parameters:
         - schema:
             type: integer
@@ -4211,8 +4211,9 @@ paths:
                         plan_amount_formatted: '$99,135.93'
                         usage_amount_in_cents: 2000
                         usage_amount_formatted: $20.00
-      operationId: readLegacyMrr
+      operationId: readyMrr
       description: 'This endpoint returns your site''s current MRR, including plan and usage breakouts.'
+      deprecated: true
       parameters:
         - schema:
             type: string
@@ -4405,7 +4406,7 @@ paths:
                       - 'Unit name: cannot be blank.'
                       - 'Pricing scheme: cannot be blank.'
                       - At least 1 price bracket must be defined
-      operationId: createProductFamilyComponent
+      operationId: createComponent
       parameters: []
       description: |-
         This request will create a component definition under the specified product family. These component definitions determine what components are named, how they are measured, and how much they cost.
@@ -5487,7 +5488,7 @@ paths:
                         default_price_point_name: Original
                         product_family_name: Chargify
                         use_site_exchange_rate: true
-      operationId: listComponentsByProductFamily
+      operationId: listComponentsForProductFamily
       description: This request will return a list of components for a particular product family.
       parameters:
         - schema:
@@ -5678,7 +5679,7 @@ paths:
                             starting_quantity: 1
                             ending_quantity: null
                             unit_price: '4.0'
-      operationId: listComponentPrices
+      operationId: listComponentPricePoints
       description: |-
         Use this endpoint to read current price points that are associated with a component.
 
@@ -5997,7 +5998,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Currency-Price'
-      operationId: createPricePointCurrency
+      operationId: createCurrencyPrices
       description: |-
         This endpoint allows you to create currency prices for a given currency that has been defined on the site level in your settings.
 
@@ -6047,7 +6048,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Currency-Price'
-      operationId: updateComponentCurrencyPrices
+      operationId: updateCurrencyPrices
       description: |-
         This endpoint allows you to update currency prices for a given currency that has been defined on the site level in your settings.
 
@@ -6205,7 +6206,8 @@ paths:
                               recurring: true
                           subscription_id: 12355
                           subscriber_name: Amy Smith
-      operationId: readLegacyMrrMovements
+      operationId: readMrrMovements
+      deprecated: true
       description: |-
         This endpoint returns your site's MRR movements.
 
@@ -6319,7 +6321,7 @@ paths:
                 properties:
                   product:
                     $ref: ../models/Product.yaml
-      operationId: createProductFamilyProduct
+      operationId: createProduct
       description: |-
         Use this method to create a product within your Chargify site.
 
@@ -6349,7 +6351,7 @@ paths:
                     tax_code: D0000000
     get:
       summary: List Products for Product Family
-      operationId: listProductsByFamily
+      operationId: listProductsForProductFamily
       responses:
         '200':
           description: OK
@@ -7563,7 +7565,7 @@ paths:
                       formatted_price: string
                       product_price_point_id: 0
                       role: baseline
-      operationId: updateCurrencyForProductPrices
+      operationId: updateProductCurrencyPrices
       description: |-
         This endpoint allows you to update the `price`s of currency prices for a given currency that exists on the product price point.
 
@@ -8814,7 +8816,7 @@ paths:
                   value:
                     errors:
                       - 'You have tried to verify this bank account 10 times. To continue trying to verify the account, please reach out to us directly.'
-      operationId: updateBankAccountVerification
+      operationId: verifyBankAccount
       description: Submit the two small deposit amounts the customer received in their bank account in order to verify the bank account. (Stripe only)
       requestBody:
         content:
@@ -9922,7 +9924,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Invoice'
-      operationId: createInvoicePayment
+      operationId: recordPaymentForInvoice
       description: |-
         This API call should be used when you want to record a payment of a given type against a specific invoice. If you would like to apply a payment across multiple invoices, you can use the Bulk Payment endpoint.
 
@@ -10110,7 +10112,7 @@ paths:
                       - Effective date is invalid or malformed
                       - Effective date must occur in the past
                       - 'Multiple applications associated to a single invoice, please aggregate and send as a single application per invoice.'
-      operationId: createExternalInvoicesPayment
+      operationId: recordExternalPaymentForInvoices
       description: |-
         This API call should be used when you want to record an external payment against multiple invoices.
 
@@ -10820,7 +10822,7 @@ paths:
                       - 'Payment amount, details, method, and memo must valid'
                       - Payment amount must be greater than zero
                       - 'If in a group, the Subscription must be the primary'
-      operationId: createSubscriptionExternalPayment
+      operationId: recordPaymentForSubscription
       description: |-
         Record an external payment made against a subscription that will pay partially or in full one or more invoices.
 
@@ -11240,7 +11242,7 @@ paths:
                         refund_amount: '0.0'
                         due_amount: '0.0'
                     public_url: 'https://www.chargifypay.com/invoice/inv_8jzrw74xq8kxr?token=fb6kpjz5rcr2vttyjs4rcv6y'
-      operationId: listConsolidatedInvoiceSegments
+      operationId: listInvoiceSegments
       description: 'Invoice segments returned on the index will only include totals, not detailed breakdowns for `line_items`, `discounts`, `taxes`, `credits`, `payments`, or `custom_fields`.'
       parameters:
         - schema:
@@ -11309,7 +11311,7 @@ paths:
                       balance_in_cents:
                         type: integer
                         description: 'The balance, in cents, of the subscription''s Prepayment account.'
-      operationId: readSubscriptionAccountBalances
+      operationId: readAccountBalances
       description: 'Returns the `balance_in_cents` of the Subscription''s Pending Discount, Service Credit, and Prepayment accounts, as well as the sum of the Subscription''s open, payable invoices.'
   '/subscriptions/{subscription_id}/components/{component_id}.json':
     parameters:
@@ -11355,7 +11357,7 @@ paths:
                       enabled: true
         '404':
           description: Not Found
-      operationId: listSubscriptionComponents
+      operationId: readSubscriptionComponent
       description: This request will list information regarding a specific component owned by a subscription.
   '/subscriptions/{subscription_id}/components.json':
     parameters:
@@ -11403,7 +11405,7 @@ paths:
                         updated_at: string
                         component_handle: string
                         archived_at: string
-      operationId: listSubscriptionAppliedComponents
+      operationId: listSubscriptionComponents
       description: |-
         This request will list a subscription's applied components.
 
@@ -11506,7 +11508,7 @@ paths:
       summary: Bulk Update Subscription Components' Price Points
       tags:
         - Subscription Components
-      operationId: updateSubscriptionComponentsPrices
+      operationId: updateSubscriptionComponentsPricePoints
       description: |-
         Updates the price points on one or more of a subscription's components.
 
@@ -11714,7 +11716,7 @@ paths:
                           handle: ea dolore dolore sunt
                           accounting_code: null
                         public_signup_pages: []
-      operationId: resetSubscriptionComponentsDefaultPrices
+      operationId: resetSubscriptionComponentsPricePoints
       description: |-
         Resets all of a subscription's components to use the current default.
 
@@ -11769,7 +11771,7 @@ paths:
                         amout_in_cents: labore in minim ad
                         success: false
                         memo: aliqua
-      operationId: createSubscriptionComponentAllocation
+      operationId: allocateComponent
       description: "This endpoint creates a new allocation, setting the current allocated quantity for the Component and recording a memo.\n\n**Notice**: Allocations can only be updated for Quantity, On/Off, and Prepaid Components.\n\n## Allocations Documentation\n\nFull documentation on how to record Allocations in the Chargify UI can be located [here](https://maxio-chargify.zendesk.com/hc/en-us/articles/5404527849997). It is focused on how allocations operate within the Chargify UI.It goes into greater detail on how the user interface will react when recording allocations.\n\nThis documentation also goes into greater detail on how proration is taken into consideration when applying component allocations.\n\n## Proration Schemes\n\nChanging the allocated quantity of a component mid-period can result in either a Charge or Credit being applied to the subscription. When creating an allocation via the API, you can pass the `upgrade_charge`, `downgrade_credit`, and `accrue_charge` to be applied.\n\n**Notice:** These proration and accural fields will be ignored for Prepaid Components since this component type always generate charges immediately without proration.\n\nFor background information on prorated components and upgrade/downgrade schemes, see [Setting Component Allocations.](https://maxio-chargify.zendesk.com/hc/en-us/articles/5404527849997#proration-upgrades-vs-downgrades).\nSee the tables below for valid values.\n\n| upgrade_charge | Definition \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_|\n|----------------|-------------------------------------------------------------------|\n| `full` \_ \_ \_ \_ |\_A charge is added for the full price of the component. \_\_\_ \_ \_ \_ \_|\n| `prorated` \_ \_ |\_A charge is added for the prorated price of the component change. |\n| `none` \_ \_ \_ \_ |\_No charge is added. \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ |\n\n| downgrade_credit | Definition \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_|\n|------------------|---------------------------------------------------|\n| `full` \_ \_ \_ \_ \_ |\_A full price credit is added for the amount owed. |\n| `prorated` \_ \_ \_ |\_A prorated credit is added for the amount owed. \_ |\n| `none` \_ \_ \_ \_ \_ |\_No charge is added. \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ |\n\n| accrue_charge | Definition \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_ \_   |\n|---------------|------------------------------------------------------------------------------------------------------------|\n| `true` \_ \_ \_ \_| Attempt to charge the customer at next renewal.                                                            |\n| `false` \_ \_ \_ |\_Attempt to charge the customer right away.\_If it fails, the charge will be accrued until the next renewal. |\n\n### Order of Resolution for upgrade_charge and downgrade_credit\n\n1. Per allocation in API call (within a single allocation of the `allocations` array)\n2. [Component-level default value](https://maxio-chargify.zendesk.com/hc/en-us/articles/5404527849997-Component-Allocations#component-allocations-0-0)\n3. Allocation API call top level (outside of the `allocations` array)\n4. [Site-level default value](https://maxio-chargify.zendesk.com/hc/en-us/articles/5404527849997#proration-schemes)\n\n### Order of Resolution for accrue charge\n\n1. Allocation API call top level (outside of the `allocations` array)\n2. [Site-level default value](https://maxio-chargify.zendesk.com/hc/en-us/articles/5404527849997#proration-schemes)\n\n**NOTE: Proration uses the current price of the component as well as the current tax rates. Changes to either may cause the prorated charge/credit to be wrong.**"
       requestBody:
         content:
@@ -11842,7 +11844,7 @@ paths:
           description: Not Found
         '422':
           description: Unprocessable Entity (WebDAV)
-      operationId: listSubscriptionComponentsAllocations
+      operationId: listAllocations
       description: |-
         This endpoint returns the 50 most recent Allocations, ordered by most recent first.
 
@@ -11950,7 +11952,7 @@ paths:
                   value:
                     errors:
                       - 'Quantity: cannot be blank.'
-      operationId: createSubscriptionComponentsAllocations
+      operationId: allocateComponents
       description: |-
         Creates multiple allocations, setting the current allocated quantity for each of the components and recording a memo. The charges and/or credits that are created will be rolled up into a single total which is used to determine whether this is an upgrade or a downgrade. Be aware of the Order of Resolutions explained below in determining the proration scheme.
 
@@ -12217,7 +12219,7 @@ paths:
                         component_id: 379512
                         'on': base
                         message: Allocations can only be updated for quantity and on/off components.
-      operationId: createSubscriptionComponentsAllocationsPreview
+      operationId: previewAllocations
       description: |-
         Chargify offers the ability to preview a potential subscription's **quantity-based** or **on/off** component allocation in the middle of the current billing period.  This is useful if you want users to be able to see the effect of a component operation before actually doing it.
 
@@ -12303,7 +12305,7 @@ paths:
                     errors:
                       - kind: base
                         message: 'Credit scheme must be one of credit, refund or none.'
-      operationId: updateSubscriptionComponentAllocation
+      operationId: updatePrepaidUsageAllocation
       description: |-
         When the expiration interval options are selected on a prepaid usage component price point, all allocations will be created with an expiration date. This expiration date can be changed after the fact to allow for extending or shortening the allocation's active window.
 
@@ -12450,7 +12452,7 @@ paths:
                   value:
                     errors:
                       - 'Price point: could not be found.'
-      operationId: createSubscriptionComponentUsage
+      operationId: createUsage
       description: |-
         ## Documentation
 
@@ -12570,7 +12572,7 @@ paths:
                         component_id: 500093
                         component_handle: handle
                         subscription_id: 22824464
-      operationId: listSubscriptionComponentsUsages
+      operationId: listUsages
       description: |-
         This request will return a list of the usages associated with a subscription for a particular metered component. This will display the previously recorded components for a subscription.
 
@@ -12642,7 +12644,7 @@ paths:
       responses:
         '200':
           description: OK
-      operationId: activateSubscriptionEventBasedComponent
+      operationId: activateEventBasedComponent
       description: |-
         In order to bill your subscribers on your Events data under the Events-Based Billing feature, the components must be activated for the subscriber.
 
@@ -12672,7 +12674,7 @@ paths:
       responses:
         '200':
           description: OK
-      operationId: deactivateSubscriptionEventBasedComponent
+      operationId: deactivateEventBasedComponent
       description: Use this endpoint to deactivate an event-based component for a single subscription. Deactivating the event-based component causes Chargify to ignore related events at subscription renewal.
   /subscriptions.json:
     post:
@@ -13797,7 +13799,7 @@ paths:
                   properties:
                     subscription:
                       $ref: ../models/Subscription.yaml
-      operationId: listSiteSubscriptions
+      operationId: listSubscriptions
       description: |-
         This method will return an array of subscriptions from a Site. Pay close attention to query string filters and pagination in order to control responses from the server.
 
@@ -13936,7 +13938,7 @@ paths:
       responses:
         '201':
           description: Created
-      operationId: createEventBasedComponentEvent
+      operationId: recordEvent
       description: |-
         ## Documentation
 
@@ -14015,7 +14017,7 @@ paths:
       responses:
         '201':
           description: Created
-      operationId: createEventBasedComponentEvents
+      operationId: recordEvents
       description: |-
         Use this endpoint to record a collection of events.
 
@@ -14221,7 +14223,7 @@ paths:
                             return_url: ''
                             return_params: ''
                             url: 'https://general-goods.chargifypay.com/subscribe/hjpvhnw63tzy'
-      operationId: listSiteOffers
+      operationId: listOffers
       description: This endpoint will list offers for a site.
   '/offers/{offer_id}.json':
     parameters:
@@ -14348,7 +14350,7 @@ paths:
                       subscription_mrr: $200.00
                       sales_rep_id: 48
                       sales_rep_name: John Candy
-      operationId: listSubscriptionsSalesCommission
+      operationId: listSalesCommissionSettings
       description: |-
         Endpoint returns subscriptions with associated sales reps
 
@@ -14527,7 +14529,7 @@ paths:
                           usage: $0.00
                           recurring: $200.00
                       test_mode: true
-      operationId: listSalesRepDetails
+      operationId: listSalesReps
       description: |-
         Endpoint returns sales rep list with details
 
@@ -14644,7 +14646,7 @@ paths:
                         recurring: $200.00
                         last_payment: '2020-04-17T08:41:03-04:00'
                         churn_date: null
-      operationId: readSalesRepSubscriptions
+      operationId: readSalesRep
       description: |-
         Endpoint returns sales rep and attached subscriptions details.
 
@@ -14837,7 +14839,7 @@ paths:
                 Example:
                   value:
                     errors: []
-      operationId: retrySubscriptionPayment
+      operationId: retrySubscription
       description: |-
         Chargify offers the ability to retry collecting the balance due on a past due Subscription without waiting for the next scheduled attempt.
 
@@ -15969,7 +15971,7 @@ paths:
                         customer_vault_token: null
                         billing_address_2: ''
                         payment_type: credit_card
-      operationId: automaticallyResumeSubscription
+      operationId: updateAutomaticSubscriptionResumption
       description: |-
         Once a subscription has been paused / put on hold, you can update the date which was specified to automatically resume the subscription.
 
@@ -16510,7 +16512,7 @@ paths:
                       - No credit card was on file for the $200.00 balance
                       - This subscription is not eligible for a prorated migration
                       - Invalid Product
-      operationId: createSubscriptionProductMigration
+      operationId: migrateSubscriptionProduct
       description: |-
         In order to create a migration, you must pass the `product_id` or `product_handle` in the object when you send a POST request. You may also pass either a `product_price_point_id` or `product_price_point_handle` to choose which price point the subscription is moved to. If no price point identifier is passed the subscription will be moved to the products default price point. The response will be the updated subscription.
 
@@ -16679,7 +16681,7 @@ paths:
                   value:
                     errors:
                       - Subscription must be active
-      operationId: createSubscriptionProductMigrationPreview
+      operationId: previewSubscriptionProductMigration
       description: |-
         ## Previewing a future date
         It is also possible to preview the migration for a date in the future, as long as it's still within the subscription's current billing period, by passing a `proration_date` along with the request (eg: `"proration_date": "2020-12-18T18:25:43.511Z"`).
@@ -16750,7 +16752,7 @@ paths:
           description: Bad Request
         '422':
           description: Unprocessable Entity (WebDAV)
-      operationId: OverrideSubscription
+      operationId: overrideSubscription
       description: |-
         This API endpoint allows you to set certain subscription fields that are usually managed for you automatically. Some of the fields can be set via the normal Subscriptions Update API, but others can only be set using this endpoint.
 
@@ -16828,7 +16830,7 @@ paths:
                     type: string
         '404':
           description: Not Found
-      operationId: createSubscriptionDelayedCancellation
+      operationId: initiateDelayedCancellation
       description: |-
         Chargify offers the ability to cancel a subscription at the end of the current billing period. This period is set by its current product.
 
@@ -16870,7 +16872,7 @@ paths:
                     message: This subscription will no longer be canceled
         '404':
           description: Not Found
-      operationId: deleteSubscriptionDelayedCancellation
+      operationId: stopDelayedCancellation
       description: |-
         Removing the delayed cancellation on a subscription will ensure that it doesn't get canceled at the end of the period that it is in. The request will reset the `cancel_at_end_of_period` flag to `false`.
 
@@ -16897,7 +16899,7 @@ paths:
                 properties:
                   subscription:
                     $ref: ../models/Subscription.yaml
-      operationId: createSubscriptionDunningCancellation
+      operationId: cancelDunning
       description: 'If a subscription is currently in dunning, the subscription will be set to active and the active Dunner will be resolved.'
   '/subscriptions/{subscription_id}/renewals/preview.json':
     parameters:
@@ -17005,7 +17007,7 @@ paths:
                           component_id: 104
                           component_handle: quantity-component
                           component_name: Quantity Component
-      operationId: createSubscriptionRenewalPreview
+      operationId: previewRenewal
       description: |-
         The Chargify API allows you to preview a renewal by posting to the renewals endpoint. Renewal Preview is an object representing a subscription’s next assessment. You can retrieve it to see a snapshot of how much your customer will be charged on their next renewal.
 
@@ -17200,7 +17202,7 @@ paths:
                 properties:
                   errors:
                     type: object
-      operationId: createSubscriptionAdhocInvoice
+      operationId: createInvoice
       description: |-
         This endpoint will allow you to create an ad hoc invoice.
 
@@ -17617,7 +17619,7 @@ paths:
                       created_at: '2020-07-31T05:52:32-04:00'
                       starting_balance_in_cents: 0
                       ending_balance_in_cents: -10000
-      operationId: createSubscriptionPrepayment
+      operationId: createPrepayment
       description: |
         ## Create Prepayment
 
@@ -17673,7 +17675,7 @@ paths:
       summary: List Prepayments
       tags:
         - Subscription Invoice Account
-      operationId: listSubscriptionPrepayments
+      operationId: listPrepayments
       responses:
         '200':
           description: OK
@@ -17772,7 +17774,7 @@ paths:
                     ending_balance_in_cents: 2000
                     entry_type: Credit
                     memo: Credit to group account
-      operationId: issueSubscriptionSeviceCredit
+      operationId: issueServiceCredit
       description: Credit will be added to the subscription in the amount specified in the request body. The credit is subsequently applied to the next generated invoice.
       requestBody:
         content:
@@ -17832,7 +17834,7 @@ paths:
                   value:
                     errors:
                       - Amount cannot exceed current service credit account balance.
-      operationId: deductSubscriptionServiceCredit
+      operationId: deductServiceCredit
       requestBody:
         content:
           application/json:
@@ -17862,7 +17864,7 @@ paths:
       description: Credit will be removed from the subscription in the amount specified in the request body. The credit amount being deducted must be equal to or less than the current credit balance.
   /subscription_groups/signup.json:
     post:
-      operationId: createSubscriptionsInGroup
+      operationId: signupWithSubscriptionGroup
       summary: Subscription Group Signup
       description: |-
         Create multiple subscriptions at once under the same customer and consolidate them into a subscription group.
@@ -18597,7 +18599,7 @@ paths:
                     meta:
                       current_page: 1
                       total_count: 1
-      operationId: listSiteSubscriptionGroups
+      operationId: listSubscriptionGroups
       description: |-
         Returns an array of subscription groups for the site. The response is paginated and will return a `meta` key with pagination information.
 
@@ -18965,7 +18967,7 @@ paths:
                         balance_in_cents: 0
         '404':
           description: Not Found
-      operationId: readSubscriptionGroupBySubscription
+      operationId: readSubscriptionGroupBySubscriptionId
       description: |-
         Use this endpoint to find subscription group associated with subscription.
 
@@ -19056,7 +19058,7 @@ paths:
                   value:
                     errors:
                       - Subscriptions group is in a past due state
-      operationId: createSubscriptionGroupDelayedCancellations
+      operationId: initiateDelayedCancellationForGroup
       description: |-
         This endpoint will schedule all subscriptions within the specified group to be canceled at the end of their billing period. The group is identified by it's uid passed in the URL.
 
@@ -19084,7 +19086,7 @@ paths:
                   value:
                     errors:
                       - Subscriptions group does not have a pending delayed cancellation
-      operationId: deleteSubscriptionGroupDelayedCancellation
+      operationId: stopDelayedCancellationForGroup
       description: Removing the delayed cancellation on a subscription group will ensure that the subscriptions do not get canceled at the end of the period. The request will reset the `cancel_at_end_of_period` flag to false on each member in the group.
   '/subscription_groups/{subscription_group_uid}/reactivate.json':
     parameters:
@@ -19842,7 +19844,7 @@ paths:
                   value:
                     errors:
                       - You can not remove primary subscription when there are others in group
-      operationId: deleteSubscriptionFromGroup
+      operationId: removeSubscriptionFromGroup
       description: 'For sites making use of the [Relationship Billing](https://chargify.zendesk.com/hc/en-us/articles/4407737494171) and [Customer Hierarchy](https://chargify.zendesk.com/hc/en-us/articles/4407746683291) features, it is possible to remove existing subscription from subscription group.'
   /subscriptions/preview.json:
     post:
@@ -19957,7 +19959,7 @@ paths:
                         end_date: '2018-10-21T21:25:21Z'
                         period_type: recurring
                         existing_balance_in_cents: 0
-      operationId: createSubscriptionPreview
+      operationId: previewSubscription
       description: |-
         The Chargify API allows you to preview a subscription by POSTing the same JSON or XML as for a subscription creation.
 
@@ -20104,7 +20106,7 @@ paths:
                       current_page: 1
                       total_pages: 1
                       per_page: 10
-      operationId: listChargifyJsKeys
+      operationId: listChargifyJsPublicKeys
       description: This endpoint returns public keys used for Chargify.js.
       parameters:
         - schema:
@@ -20150,7 +20152,7 @@ paths:
                   value:
                     errors:
                       - Consolidated proforma invoice generation already in progress
-      operationId: createConsolidatedSubscriptionProformaInvoice
+      operationId: createConsolidatedProformaInvoice
       description: |-
         This endpoint will trigger the creation of a consolidated proforma invoice asynchronously. It will return a 201 with no message, or a 422 with any errors. To find and view the new consolidated proforma invoice, you may poll the subscription group listing for proforma invoices; only one consolidated proforma invoice may be created per group at a time.
 
@@ -20395,7 +20397,7 @@ paths:
                       - 'Coupon Codes: ''COUPONB'' - That coupon is not stackable'
                     subscription:
                       - Coupon is invalid.
-      operationId: applySubscriptionCouponCodes
+      operationId: applyCouponToSubscription
       description: |-
         An existing subscription can accommodate multiple discounts/coupon codes. This is only applicable if each coupon is stackable. For more information on stackable coupons, we recommend reviewing our [coupon documentation.](https://chargify.zendesk.com/hc/en-us/articles/4407755909531#stackable-coupons)
 
@@ -20512,7 +20514,7 @@ paths:
                   value:
                     errors:
                       - this subscription is not eligible to create proforma invoices
-      operationId: createSubscriptionProformaInvoice
+      operationId: createProformaInvoice
       description: |-
         This endpoint will create a proforma invoice and return it as a response. If the information becomes outdated, simply void the old proforma invoice and generate a new one.
 
@@ -20534,7 +20536,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Proforma-Invoice'
-      operationId: listSubscriptionProformaInvoices
+      operationId: listProformaInvoices
       description: 'By default, proforma invoices returned on the index will only include totals, not detailed breakdowns for `line_items`, `discounts`, `taxes`, `credits`, `payments`, or `custom_fields`. To include breakdowns, pass the specific field as a key in the query with a value set to `true`.'
       parameters:
         - schema:
@@ -20723,7 +20725,7 @@ paths:
                   example-1:
                     errors:
                       - this subscription is not eligible to create proforma invoices
-      operationId: createSubscriptionProformaInvoicePreview
+      operationId: previewProformaInvoice
       description: |-
         Return a preview of the data that will be included on a given subscription's proforma invoice if one were to be generated. It will have similar line items and totals as a renewal preview, but the response will be presented in the format of a proforma invoice. Consequently it will include additional information such as the name and addresses that will appear on the proforma invoice.
 
@@ -20763,7 +20765,7 @@ paths:
                   value:
                     errors:
                       - 'cc_recipient_emails: must be a valid email address'
-      operationId: deliverInvoiceEmail
+      operationId: sendInvoice
       description: |-
         This endpoint allows for invoices to be programmatically delivered via email. This endpoint supports the delivery of both ad-hoc and automatically generated invoices. Additionally, this endpoint supports email delivery to direct recipients, carbon-copy (cc) recipients, and blind carbon-copy (bcc) recipients.
 
@@ -20941,7 +20943,7 @@ paths:
                   value:
                     errors:
                       - Invoice must have an open status
-      operationId: updateInvoiceCustomerDetails
+      operationId: previewCustomerInformationChanges
       description: |-
         Customer information may change after an invoice is issued which may lead to a mismatch between customer information that are present on an open invoice and actual customer information. This endpoint allows to preview these differences, if any.
 
@@ -21119,7 +21121,7 @@ paths:
                   value:
                     errors:
                       - Invoice must have an open status
-      operationId: updateCustomerInformationForOpenInvoice
+      operationId: updateCustomerInformation
       description: |-
         This endpoint updates customer information on an open invoice and returns the updated invoice. If you would like to preview changes that will be applied, use the `/invoices/{uid}/customer_information/preview.json` endpoint before.
 
@@ -21285,7 +21287,7 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/Subscriptions-Component'
-      operationId: listSiteSubscriptionComponents
+      operationId: listSubscriptionComponentsForSite
       description: This request will list components applied to each subscription.
       parameters:
         - schema:
@@ -21541,7 +21543,7 @@ paths:
                         type: array
                         items:
                           type: string
-      operationId: createComponentPricePointSegment
+      operationId: createSegment
       requestBody:
         content:
           application/json:
@@ -21633,7 +21635,7 @@ paths:
         description: ID or Handle for the Price Point belonging to the Component
     get:
       summary: List Segments for a Price Point
-      operationId: listComponentPricePointSegments
+      operationId: listSegmentsForPricePoint
       responses:
         '200':
           description: OK
@@ -21903,7 +21905,7 @@ paths:
                         type: array
                         items:
                           type: string
-      operationId: updateComponentPricePointSegment
+      operationId: updateSegment
       requestBody:
         content:
           application/json:
@@ -21940,7 +21942,7 @@ paths:
         You may specify component and/or price point by using either the numeric ID or the `handle:gold` syntax.
     delete:
       summary: Delete Single Segment
-      operationId: deleteComponentSegment
+      operationId: deleteSegment
       responses:
         '204':
           description: No Content
@@ -22106,7 +22108,7 @@ paths:
                         '1':
                           pricing_scheme:
                             - 'Pricing scheme: cannot be blank'
-      operationId: createComponentPricePointSegments
+      operationId: createSegments
       requestBody:
         content:
           application/json:
@@ -22306,7 +22308,7 @@ paths:
                         '1':
                           pricing_scheme:
                             - 'Pricing scheme: cannot be blank'
-      operationId: updateComponentPricePointSegments
+      operationId: updateSegments
       requestBody:
         content:
           application/json:
@@ -22428,7 +22430,7 @@ paths:
                   value:
                     errors:
                       - Cannot generate an invoice in advance when a subscription uses prepaid components
-      operationId: issueSubscriptionInvoiceInAdvance
+      operationId: issueAdvanceInvoice
       description: |
         Generate an invoice in advance for a subscription's next renewal date. [Please see our docs](reference/Chargify-API.v1.yaml/components/schemas/Invoice) for more information on advance invoices, including eligibility on generating one; for the most part, they function like any other invoice, except they are issued early and have special behavior upon being voided.
         A subscription may only have one advance invoice per billing period. Attempting to issue an advance invoice when one already exists will return an error.
@@ -22473,7 +22475,7 @@ paths:
           description: Forbidden
         '404':
           description: Not Found
-      operationId: readSubscriptionUpcomingRenewalAdvanceInvoice
+      operationId: readAdvanceInvoice
       description: 'Once an advance invoice has been generated for a subscription''s upcoming renewal, it can be viewed through this endpoint. There can only be one advance invoice per subscription per billing cycle.'
   '/subscriptions/{subscription_id}/advance_invoice/void.json':
     parameters:
@@ -22585,7 +22587,8 @@ paths:
                     errors:
                       at_time:
                         - 'supplied value is invalid, expected ISO 8601 format'
-      operationId: readSubscriptionLegacyMrr
+      operationId: listMrrPerSubscription
+      deprecated: true
       description: 'This endpoint returns your site''s current MRR, including plan and usage breakouts split per subscription.'
       parameters:
         - schema:
@@ -22718,7 +22721,7 @@ paths:
                       refund:
                         amount_in_cents:
                           - Refund amount exceeds prepayment amount
-      operationId: refundSubscriptionPrepayment
+      operationId: refundPrepayment
       description: |-
         This endpoint will refund, completely or partially, a particular prepayment applied to a subscription. The `prepayment_id` will be the account transaction ID of the original payment. The prepayment must have some amount remaining in order to be refunded.
 
@@ -22825,7 +22828,7 @@ paths:
                         use_site_exchange_rate: true
                         tax_code: string
                         default_product_price_point_id: 0
-      operationId: listSiteProducts
+      operationId: listProducts
       description: This method allows to retrieve a list of Products belonging to a Site.
       parameters:
         - schema:
@@ -23030,7 +23033,7 @@ paths:
                   value:
                     errors:
                       - 'start_date supplied value is invalid, expected ISO 8601 format'
-      operationId: listSiteComponentPricePoints
+      operationId: listComponentPricePoints
       description: This method allows to retrieve a list of Components Price Points belonging to a Site.
       parameters:
         - schema:
@@ -23178,7 +23181,7 @@ paths:
                     errors:
                       - 'date_field must be one of: created_at, updated_at'
                       - 'start_date supplied value is invalid, expected ISO 8601 format'
-      operationId: listSiteProductPricePoints
+      operationId: listProductPricePoints
       description: This method allows retrieval of a list of Products Price Points belonging to a Site.
       parameters:
         - schema:
@@ -23439,7 +23442,7 @@ paths:
                     errors:
                       base:
                         - currency must be a string
-      operationId: createSubscriptionSignupProformaInvoice
+      operationId: createSignupProformaInvoice
       description: |-
         This endpoint is only available for Relationship Invoicing sites. It cannot be used to create consolidated proforma invoices or preview prepaid subscriptions.
 
@@ -23553,7 +23556,7 @@ paths:
                     errors:
                       base:
                         - organization must be a string
-      operationId: createSubscriptionSignupProformaPreview
+      operationId: previewSignupProformaInvoice
       description: |-
         This endpoint is only available for Relationship Invoicing sites. It cannot be used to create consolidated proforma invoice previews or preview prepaid subscriptions.
 
@@ -23599,7 +23602,7 @@ paths:
       summary: List Exported Proforma Invoices
       tags:
         - API Exports
-      operationId: listProformaInvoicesRowsExport
+      operationId: listExportedProformaInvoices
       description: |-
         This API returns an array of exported proforma invoices for a provided `batch_id`. Pay close attention to pagination in order to control responses from the server.
 
@@ -23640,7 +23643,7 @@ paths:
       summary: List Exported Invoices
       tags:
         - API Exports
-      operationId: listInvoicesRowsExport
+      operationId: listExportedInvoices
       description: |-
         This API returns an array of exported invoices for a provided `batch_id`. Pay close attention to pagination in order to control responses from the server.
 
@@ -23681,7 +23684,7 @@ paths:
       summary: List Exported Subscriptions
       tags:
         - API Exports
-      operationId: listSubscriptionsExport
+      operationId: listExportedSubscriptions
       description: |-
         This API returns an array of exported subscriptions for a provided `batch_id`. Pay close attention to pagination in order to control responses from the server.
 
@@ -23716,7 +23719,7 @@ paths:
       summary: Create Proforma Invoices Export
       tags:
         - API Exports
-      operationId: createProformaInvoicesExport
+      operationId: exportProformaInvoices
       description: |-
         This API creates a proforma invoices export and returns a batchjob object.
 
@@ -23749,7 +23752,7 @@ paths:
       summary: Create Invoices Export
       tags:
         - API Exports
-      operationId: createInvoicesExport
+      operationId: exportInvoices
       description: This API creates an invoices export and returns a batchjob object.
       responses:
         '201':
@@ -23775,7 +23778,7 @@ paths:
       summary: Create Subscriptions Export
       tags:
         - API Exports
-      operationId: createSubscriptionsExport
+      operationId: exportSubscriptions
       description: This API creates a subscriptions export and returns a batchjob object.
       responses:
         '201':

--- a/reference/Chargify-API.v1.yaml
+++ b/reference/Chargify-API.v1.yaml
@@ -837,7 +837,7 @@ paths:
                     sticky: true
     delete:
       summary: Delete Subscription Note
-      operationId: delete-subscriptions-subscription_id-notes.json
+      operationId: deleteSubscriptionNote
       tags:
         - Subscription Notes
       responses:
@@ -1349,7 +1349,7 @@ paths:
       summary: Delete Customer
       tags:
         - Customers
-      operationId: delete-customers-id-.json
+      operationId: deleteCustomer
       responses:
         '204':
           description: No Content
@@ -1653,7 +1653,7 @@ paths:
                     uninvited_count: 8
         '422':
           description: Unprocessable Entity (WebDAV)
-      operationId: delete-portal-customers-customer_id-invitations-revoke.json
+      operationId: revokeCustomerPortalAccess
       description: |-
         You can revoke a customer's Billing Portal invitation.
 
@@ -2011,7 +2011,7 @@ paths:
                     ok: ok
         '404':
           description: Not Found
-      operationId: delete-reason_codes-reason_code_id-.json
+      operationId: deleteReasonCode
       description: This method gives a merchant the option to delete one reason code from the Churn Reason Codes. This code will be immediately removed. This action is not reversable.
   '/{resource_type}/metafields.json':
     parameters:
@@ -2234,7 +2234,7 @@ paths:
       tags:
         - Custom Fields
       summary: Delete Metafield
-      operationId: delete-resource_type-metafields.json
+      operationId: deleteMetafield
       responses:
         '200':
           description: OK
@@ -2408,7 +2408,7 @@ paths:
           description: OK
         '404':
           description: Not Found
-      operationId: delete-resource_type-resource_id-metadata.json
+      operationId: deleteResourceMetadata
       description: |-
         This method removes the metadata from the subscriber/customer cited.
 
@@ -3007,7 +3007,7 @@ paths:
                       stackable: true
                       compounding_strategy: compound
                       coupon_restrictions: []
-      operationId: delete-product_families-product_family_id-coupons-coupon_id-.json
+      operationId: deleteProductFamilyCoupon
       description: |-
         You can archive a Coupon via the API with the archive method.
         Archiving makes that Coupon unavailable for future use, but allows it to remain attached and functional on existing Subscriptions that are using it.
@@ -3636,7 +3636,7 @@ paths:
           description: OK
         '404':
           description: Not Found
-      operationId: delete-coupons-coupon_id-codes-subcode-.json
+      operationId: deleteCouponSubcode
       description: |-
         ## Example
 
@@ -5202,7 +5202,7 @@ paths:
                   value:
                     errors:
                       - Component cannot be archived. Please make sure it hasn't already been archived.
-      operationId: delete-product_families-product_family_id-components-component_id-.json
+      operationId: archiveComponent
       description: Sending a DELETE request to this endpoint will archive the component. All current subscribers will be unffected; their subscription/purchase will continue to be charged as usual.
   /components.json:
     get:
@@ -5920,7 +5920,7 @@ paths:
                           starting_quantity: 101
                           ending_quantity: null
                           unit_price: '4.0'
-      operationId: delete-components-component_id-price_points-price_point_id-.json
+      operationId: archiveComponentPricePoint
       description: A price point can be archived at any time. Subscriptions using a price point that has been archived will continue using it until they're moved to another price point.
   '/components/{component_id}/price_points/{price_point_id}/unarchive.json':
     parameters:
@@ -6680,7 +6680,7 @@ paths:
       summary: Archive Product
       tags:
         - Products
-      operationId: delete-products-product_id-.json
+      operationId: archiveProduct
       responses:
         '200':
           description: OK
@@ -7252,7 +7252,7 @@ paths:
                       archived_at: 'Tue, 30 Oct 2018 18:49:47 EDT -04:00'
                       created_at: 'Tue, 23 Oct 2018 18:49:47 EDT -04:00'
                       updated_at: 'Tue, 23 Oct 2018 18:49:47 EDT -04:00'
-      operationId: delete-products-product_id-price_points-price_point_id-.json
+      operationId: archiveProductPricePoint
       description: Use this endpoint to archive a product price point.
   '/products/{product_id}/price_points/{price_point_id}/unarchive.json':
     parameters:
@@ -8672,7 +8672,7 @@ paths:
                   value:
                     errors:
                       - The payment profile is in use by one or more subscriptions and cannot be deleted
-      operationId: delete-payment_profiles-payment_profile_id-.json
+      operationId: deleteUnusedPaymentProfile
       description: |-
         Deletes an unused payment profile.
 
@@ -8696,7 +8696,7 @@ paths:
       responses:
         '204':
           description: No Content
-      operationId: delete-subscriptions-subscription_id-payment_profiles-payment_profile_id-.json
+      operationId: deleteSubscriptionsPaymentProfile
       description: |-
         This will delete a payment profile belonging to the customer on the subscription.
 
@@ -12367,7 +12367,7 @@ paths:
                     errors:
                       - kind: base
                         message: 'Credit scheme must be one of credit, refund or none.'
-      operationId: delete-subscriptions-subscription_id-components-component_id-allocations-allocation_id-.json
+      operationId: deletePrepaidUsageAllocation
       description: |-
         Prepaid Usage components are unique in that their allocations are always additive. In order to reduce a subscription's allocated quantity for a prepaid usage component each allocation must be destroyed individually via this endpoint.
 
@@ -15216,7 +15216,7 @@ paths:
       summary: Cancel Subscription
       tags:
         - Subscription Status
-      operationId: delete-subscriptions-subscription_id-.json
+      operationId: cancelSubscription
       responses:
         '200':
           description: OK
@@ -16870,7 +16870,7 @@ paths:
                     message: This subscription will no longer be canceled
         '404':
           description: Not Found
-      operationId: delete-subscriptions-subscription_id-delayed_cancel.json
+      operationId: deleteSubscriptionDelayedCancellation
       description: |-
         Removing the delayed cancellation on a subscription will ensure that it doesn't get canceled at the end of the period that it is in. The request will reset the `cancel_at_end_of_period` flag to `false`.
 
@@ -18860,7 +18860,7 @@ paths:
                     deleted: true
         '404':
           description: Not Found
-      operationId: delete-subscription_groups-uid-.json
+      operationId: deleteSubscriptionGroup
       description: |-
         Use this endpoint to delete subscription group.
         Only groups without members can be deleted
@@ -19084,7 +19084,7 @@ paths:
                   value:
                     errors:
                       - Subscriptions group does not have a pending delayed cancellation
-      operationId: delete-subscription_groups-uid-delayed_cancel.json
+      operationId: deleteSubscriptionGroupDelayedCancellation
       description: Removing the delayed cancellation on a subscription group will ensure that the subscriptions do not get canceled at the end of the period. The request will reset the `cancel_at_end_of_period` flag to false on each member in the group.
   '/subscription_groups/{subscription_group_uid}/reactivate.json':
     parameters:
@@ -19211,7 +19211,7 @@ paths:
       responses:
         '204':
           description: No Content
-      operationId: delete-subscription_groups-subscription_group_uid-payment_profiles-payment_profile_id-.json
+      operationId: deleteSubscriptionGroupPaymentProfile
       description: |-
         This will delete a Payment Profile belonging to a Subscription Group.
 
@@ -19842,7 +19842,7 @@ paths:
                   value:
                     errors:
                       - You can not remove primary subscription when there are others in group
-      operationId: delete-subscriptions-subscription_id-group.json
+      operationId: deleteSubscriptionFromGroup
       description: 'For sites making use of the [Relationship Billing](https://chargify.zendesk.com/hc/en-us/articles/4407737494171) and [Customer Hierarchy](https://chargify.zendesk.com/hc/en-us/articles/4407746683291) features, it is possible to remove existing subscription from subscription group.'
   /subscriptions/preview.json:
     post:
@@ -20464,7 +20464,7 @@ paths:
                   value:
                     subscription:
                       - There's no coupon applied to this subscription
-      operationId: delete-subscriptions-subscription_id-remove_coupon.json
+      operationId: deleteCouponFromSubscription
       description: |-
         Use this endpoint to remove a coupon from an existing subscription.
 
@@ -21940,7 +21940,7 @@ paths:
         You may specify component and/or price point by using either the numeric ID or the `handle:gold` syntax.
     delete:
       summary: Delete Single Segment
-      operationId: delete-components-component_id-price_points-price_point_id-segments-id-.json
+      operationId: deleteComponentSegment
       responses:
         '204':
           description: No Content

--- a/reference/Chargify-API.v1.yaml
+++ b/reference/Chargify-API.v1.yaml
@@ -15969,7 +15969,7 @@ paths:
                         customer_vault_token: null
                         billing_address_2: ''
                         payment_type: credit_card
-      operationId: pauseSubscription
+      operationId: automaticallyResumeSubscription
       description: |-
         Once a subscription has been paused / put on hold, you can update the date which was specified to automatically resume the subscription.
 
@@ -20150,7 +20150,7 @@ paths:
                   value:
                     errors:
                       - Consolidated proforma invoice generation already in progress
-      operationId: createSubscriptionProformaInvoice
+      operationId: createConsolidatedSubscriptionProformaInvoice
       description: |-
         This endpoint will trigger the creation of a consolidated proforma invoice asynchronously. It will return a 201 with no message, or a 422 with any errors. To find and view the new consolidated proforma invoice, you may poll the subscription group listing for proforma invoices; only one consolidated proforma invoice may be created per group at a time.
 


### PR DESCRIPTION
Ticket:
https://maxioevolution.atlassian.net/browse/DE-312

Type of change:
 internal

What
This PR updates the OAS `operationId`s with human readable labels

How
operationId is optional property for an operation but it’s used for method names in generated SDK.

e.g. post-portal-customers-customer_id-enable.json → postPortalCustomersCustomerIdEnableJson - this name is complicated, is postfixed with Json and is meaningless. Better name would be e.g. enableBillingPortal.

So these operationIds need to be meaningful as they will be most visible and most used part in SDK.