### PR TITLE
[DE-248] DE-398 Add more validation rules for Spectral

### DIFF
--- a/.github/workflows/validate-sdk.yml
+++ b/.github/workflows/validate-sdk.yml
@@ -31,7 +31,7 @@ jobs:
         run: npx prettier . --check
       - name: Run Spectral validator
         shell: bash
-        run: spectral lint -v -F warn ./reference/Chargify-API.v1.yaml
+        run: spectral lint -v -F warn -r .spectral-build.yaml -f github-actions ./reference/Chargify-API.v1.yaml
   run-generator:
     runs-on: ubuntu-latest
     defaults:

--- a/.spectral-build.yaml
+++ b/.spectral-build.yaml
@@ -1,0 +1,9 @@
+extends: [".spectral.yaml"]
+rules:
+  array-properties-must-have-items-with-type: info
+  array-parameters-must-have-items-with-type: info
+  array-parameters-must-have-serialisation-info: info
+  element-must-have-description: info
+  schema-must-be-valid: info
+  use-valid-media-type: info
+  reuse-schemas-in-media-types: info

--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -1,19 +1,94 @@
 extends: ["spectral:oas"]
 formats: ["oas3_1"]
+functionsDir: "./spectral"
+functions:
+  - arrayPropertiesShouldHaveItemType
+  - arrayParametersShouldHaveSerializationFormat
+  - arrayParametersShouldHaveItemType
+  - schemaMustBeValid
+  - schemaMustBeReused
 
 aliases:
   PathItem:
     - $.paths[*]
-  MethodObject:
+  OperationObject:
     - "#PathItem[get,put,post,delete,options,head,patch,trace]"
+  MediaTypeObjects:
+    - "#OperationObject.requestBody.content[*]"
+    - "#OperationObject.responses[*].content[*]"
+  ParameterObjects:
+    - "$..*.parameters[*]"
+  DescribableObjects:
+    - "$.info"
+    - "#OperationObject"
+    - "#OperationObject.responses[*]"
+    - "#ParameterObjects"
+    - "$.servers[*]"
 
 rules:
   camel-case-operation-id:
-    description: operationId should be camelCased.
-    given: "#MethodObject"
+    description: operationId should be camelCased
+    given: "#OperationObject"
     severity: error
     then:
       field: operationId
       function: casing
       functionOptions:
         type: camel
+  array-properties-must-have-items-with-type:
+    description: Ensures all array properties have an items attribute with a type or $ref
+    given: "$..*.properties[*]"
+    severity: error
+    message: "Property of type 'array' must contain valid 'items.type' property"
+    then:
+      function: arrayPropertiesShouldHaveItemType
+  array-parameters-must-have-items-with-type:
+    description: Ensures all array parameters have an items attribute with a type or $ref
+    given: "#ParameterObjects"
+    severity: error
+    message: "Parameter of type 'array' must contain valid 'items.type' property"
+    then:
+      function: arrayParametersShouldHaveItemType
+  array-parameters-must-have-serialisation-info:
+    description: Array parameters should explicitly define serialization using form and explode
+    given: "#ParameterObjects"
+    severity: warn
+    message: "{{error}}"
+    then:
+      function: arrayParametersShouldHaveSerializationFormat
+  element-must-have-description:
+    description: Parameters must have a description
+    given: "#DescribableObjects"
+    severity: warn
+    recommended: true
+    message: "Element must have a description"
+    then:
+      field: description
+      function: truthy
+  schema-must-be-valid:
+    description: Schema should use $ref or valid type and properties
+    given: "$..*.schema"
+    severity: error
+    message: "{{error}}"
+    then:
+      function: schemaMustBeValid
+  use-valid-media-type:
+    description: Use proper media type for request/response
+    given: "#MediaTypeObjects~"
+    severity: error
+    message: "Use application/json, application/xml or multipart/form-data for request/response 'content'"
+    then:
+      function: enumeration
+      functionOptions:
+        values:
+          - application/json
+          - application/xml
+          - multipart/form-data
+  reuse-schemas-in-media-types:
+    description: Use $ref instead of inline schema
+    given: "#MediaTypeObjects..schema"
+    severity: error
+    resolved: false
+    message: "{{error}}"
+    then:
+      function: schemaMustBeReused

--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -17,7 +17,7 @@ aliases:
     - "#OperationObject.requestBody.content[*]"
     - "#OperationObject.responses[*].content[*]"
   ParameterObjects:
-    - "$..*.parameters[*]"
+    - "$..parameters[*]"
   DescribableObjects:
     - "$.info"
     - "#OperationObject"
@@ -37,7 +37,7 @@ rules:
         type: camel
   array-properties-must-have-items-with-type:
     description: Ensures all array properties have an items attribute with a type or $ref
-    given: "$..*.properties[*]"
+    given: "$..properties[*]"
     severity: error
     message: "Property of type 'array' must contain valid 'items.type' property"
     then:
@@ -89,6 +89,6 @@ rules:
     given: "#MediaTypeObjects..schema"
     severity: error
     resolved: false
-    message: "Inline schema for media type: {{error}}"
+    message: "{{error}}"
     then:
       function: schemaMustBeReused

--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -85,10 +85,10 @@ rules:
           - application/xml
           - multipart/form-data
   reuse-schemas-in-media-types:
-    description: Use $ref instead of inline schema
+    description: Use $ref instead of inline schema for request/response
     given: "#MediaTypeObjects..schema"
     severity: error
     resolved: false
-    message: "{{error}}"
+    message: "Inline schema for media type: {{error}}"
     then:
       function: schemaMustBeReused

--- a/reference/Chargify-API.v1.yaml
+++ b/reference/Chargify-API.v1.yaml
@@ -24273,6 +24273,8 @@ components:
       properties:
         prepaid_configuration:
           $ref: "#/components/schemas/Upsert-Prepaid-Configuration"
+      required:
+        - prepaid_configuration
     Create-or-Update-Product:
       title: Create or Update Product
       type: object
@@ -24620,6 +24622,8 @@ components:
       properties:
         subscription:
           $ref: "#/components/schemas/Create-Subscription"
+      required:
+        - subscription
     Subscription-Custom-Price:
       title: Custom price used for Subscription Create/Update
       type:
@@ -27448,6 +27452,8 @@ components:
       properties:
         subscription:
           $ref: "#/components/schemas/Update-Subscription"
+      required:
+        - subscription
     Override-Subscription:
       title: Override Subscription
       type: object
@@ -27473,6 +27479,8 @@ components:
       properties:
         subscription:
           $ref: "#/components/schemas/Override-Subscription"
+      required:
+        - subscription
     Usage:
       title: Usage
       type: object

--- a/spectral/arrayParametersShouldHaveItemType.js
+++ b/spectral/arrayParametersShouldHaveItemType.js
@@ -1,0 +1,26 @@
+export default (param, _, context) => {
+  // if this is actually a property called properties, ignore
+  if (context.path.join(".").includes("properties.properties")) {
+    return;
+  }
+
+  // check if the param is an array
+  if (!(param.schema && param.schema.type === "array")) return;
+
+  if (
+    !param.schema.items ||
+    !(
+      param.schema.items.type ||
+      param.schema.items["$ref"] ||
+      param.schema.items.oneOf ||
+      param.schema.items.anyOf ||
+      param.schema.items.allOf
+    )
+  ) {
+    return [
+      {
+        message: "All parameters of type array need an item type or $ref",
+      },
+    ];
+  }
+};

--- a/spectral/arrayParametersShouldHaveItemType.js
+++ b/spectral/arrayParametersShouldHaveItemType.js
@@ -1,9 +1,4 @@
 export default (param, _, context) => {
-  // if this is actually a property called properties, ignore
-  if (context.path.join(".").includes("properties.properties")) {
-    return;
-  }
-
   // check if the param is an array
   if (!(param.schema && param.schema.type === "array")) return;
 

--- a/spectral/arrayParametersShouldHaveSerializationFormat.js
+++ b/spectral/arrayParametersShouldHaveSerializationFormat.js
@@ -1,0 +1,17 @@
+export default (param, _, context) => {
+  // if this is actually a property called properties, ignore
+  if (context.path.join(".").includes("properties.properties")) {
+    return;
+  }
+
+  // check if the param is an array
+  if (!(param.schema && param.schema.type === "array")) return;
+
+  if (!param.style || param.explode == null) {
+    return [
+      {
+        message: `Array parameter "${param.name}" should have an explicit serialisation using 'style' and 'explode'`,
+      },
+    ];
+  }
+};

--- a/spectral/arrayParametersShouldHaveSerializationFormat.js
+++ b/spectral/arrayParametersShouldHaveSerializationFormat.js
@@ -1,9 +1,4 @@
 export default (param, _, context) => {
-  // if this is actually a property called properties, ignore
-  if (context.path.join(".").includes("properties.properties")) {
-    return;
-  }
-
   // check if the param is an array
   if (!(param.schema && param.schema.type === "array")) return;
 

--- a/spectral/arrayPropertiesShouldHaveItemType.js
+++ b/spectral/arrayPropertiesShouldHaveItemType.js
@@ -1,0 +1,26 @@
+export default (param, _, context) => {
+  // if this is actually a property called properties, ignore
+  if (context.path.join(".").includes("properties.properties")) {
+    return;
+  }
+
+  // check if the param is an array
+  if (param.type !== "array") return;
+
+  if (
+    !param.items ||
+    !(
+      param.items.type ||
+      param.items["$ref"] ||
+      param.items.oneOf ||
+      param.items.anyOf ||
+      param.items.allOf
+    )
+  ) {
+    return [
+      {
+        message: `All properties of type array need an item type or $ref`,
+      },
+    ];
+  }
+};

--- a/spectral/schemaMustBeReused.js
+++ b/spectral/schemaMustBeReused.js
@@ -1,0 +1,21 @@
+export default (schema, _, context) => {
+  if (schema.oneOf || schema.anyOf || schema.allOf) return;
+
+  if (schema.type === "array") {
+    if (schema.items && !schema.items["$ref"]) {
+      return [
+        {
+          message: "Use $ref in 'items' field for 'array' type",
+        },
+      ];
+    } else return;
+  }
+
+  if (!schema["$ref"]) {
+    return [
+      {
+        message: "Use $ref instead of inline schema",
+      },
+    ];
+  }
+};

--- a/spectral/schemaMustBeReused.js
+++ b/spectral/schemaMustBeReused.js
@@ -2,7 +2,7 @@ export default (schema, _, context) => {
   if (schema.oneOf || schema.anyOf || schema.allOf) return;
 
   if (schema.type === "array") {
-    if (schema.items && !schema.items["$ref"]) {
+    if (schema.items && schema.items["$ref"] === "object") {
       return [
         {
           message: "Use $ref in 'items' field for 'array' type",
@@ -10,6 +10,8 @@ export default (schema, _, context) => {
       ];
     } else return;
   }
+
+  if (schema.type !== "object") return;
 
   if (!schema["$ref"]) {
     return [

--- a/spectral/schemaMustBeValid.js
+++ b/spectral/schemaMustBeValid.js
@@ -1,0 +1,22 @@
+export default (schema, _, context) => {
+  if (schema.oneOf || schema.anyOf || schema.allOf) return;
+
+  if (
+    schema.type === "object" &&
+    (!schema.properties || Object.keys(schema.properties).length === 0)
+  ) {
+    return [
+      {
+        message: "Schema for type 'object' must define valid 'properties'",
+      },
+    ];
+  }
+
+  if (!schema.type && !schema.properties && !schema["$ref"]) {
+    return [
+      {
+        message: "Schema must use '$ref' or 'type' with 'properties'",
+      },
+    ];
+  }
+};


### PR DESCRIPTION
Added a new ruleset for validation pipeline.
New rules introduced into the main ruleset would be disabled for validation pipeline (info level). After all problems with rule is fixed then rule would be promoted to validation pipeline and breaking the rule would not be allowed any more.

Added rules:
- all array parameters and properties should be properly defined. array should contain items with proper type
- all array query parameters must have explicit style and explode information for proper serialisation
- all operations, responses, parameters, servers should have description
- schema must be properly defined (no missing properties)
- only application/json, application/xml, multipart/form-data are allowed in media types
- response/request should not be inlined - $ref is required

Those rules will help with splitting the document and improving developer experience and generated SDK.