### PR TITLE
PAYM-609 CardType values updated in the docs, and made enum

### DIFF
--- a/components/schemas/Credit-Card-Payment-Profile.yaml
+++ b/components/schemas/Credit-Card-Payment-Profile.yaml
@@ -11,6 +11,40 @@ properties:
     type: string
   card_type:
     type: string
+    enum:
+      - visa
+      - master
+      - elo
+      - cabal
+      - alelo
+      - discover
+      - american_express
+      - naranja
+      - diners_club
+      - jcb
+      - dankort
+      - maestro
+      - maestro_no_luhn
+      - forbrugsforeningen
+      - sodexo
+      - alia
+      - vr
+      - unionpay
+      - carnet
+      - cartes_bancaires
+      - olimpica
+      - creditel
+      - confiable
+      - synchrony
+      - routex
+      - mada
+      - bp_plus
+      - passcard
+      - edenred
+      - anda
+      - tarjeta-d
+      - hipercard
+      - bogus
   expiration_month:
     type: integer
   expiration_year:


### PR DESCRIPTION
corresponding JIRA ticket:
- https://maxioevolution.atlassian.net/browse/PAYM-609


Documentation does not mention now directly neither those two card numbers as in the ticket, nor `unionpay` or `diners_club` card_types. Since this is the case, no changes will be made in that regard.

I checked that for these two card types API does indeed return correct `card_type`, that is `unionpay` or `diners_club` both on local and staging.
What they say in the ticket is then clearly no longer the case. 
Ticket was created Dec '22, it must have been fixed since then.
```
UnionPay 6200000000000005 response came in as “card_type”: discover.   <--- no longer true
Diners Club 3056930009020004 response came in as “card_type”: null.   <--- no longer true
```

In the interest of API Docs clarity, IMHO remaining thing to do here is only to enumerize all possible values of `card_type`
treating that service object as a source of truth: https://github.com/maxio-com/active_merchant/blob/master/lib/active_merchant/billing/credit_card_methods.rb#L10

#### Some evidence to what said above:
<img width="534" alt="Screenshot 2023-09-04 at 10 54 18" src="https://github.com/maxio-com/stoplight-platform-api-docs/assets/142793346/24cb9fd7-8a32-4328-bad1-c56fb9ccc1f5">
<img width="568" alt="Screenshot 2023-09-04 at 10 55 09" src="https://github.com/maxio-com/stoplight-platform-api-docs/assets/142793346/8068a052-bf50-48db-8409-b0dba5219887">
<img width="409" alt="Screenshot 2023-09-04 at 12 42 45" src="https://github.com/maxio-com/stoplight-platform-api-docs/assets/142793346/66d78579-bbe4-4c59-9ae5-c0a8adf9181a">

