### PR TITLE
[documentation] PAYM-757 Metafield Values in Payer Attributes 

### DIFF
--- a/components/schemas/Create-Subscription.yaml
+++ b/components/schemas/Create-Subscription.yaml
@@ -65,9 +65,7 @@ properties:
   calendar_billing:
     $ref: "./Calendar-Billing.yaml"
   metafields:
-    allOf:
-      - $ref: "./Metafields.yaml"
-    description: "(Optional) A set of key/value pairs representing custom fields and their values. Metafields will be created “on-the-fly” in your site for a given key, if they have not been created yet."
+    $ref: "./Metafields-Values.yaml"
   customer_reference:
     type: string
     description: "The reference value (provided by your app) of an existing customer within Chargify. Required, unless a `customer_id` or a set of `customer_attributes` is given."

--- a/components/schemas/Metafield-Input.yaml
+++ b/components/schemas/Metafield-Input.yaml
@@ -2,6 +2,7 @@ title: Metafield Input
 type: string
 description: "Indicates how data should be added to the metafield. For example, a text type is just a string, so a given metafield of this type can have any value attached. On the other hand, dropdown and radio have a set of allowed values that can be input, and appear differently on a Public Signup Page."
 enum:
+  - balance_tracker
   - text
   - radio
   - dropdown

--- a/components/schemas/Metafields-Values.yaml
+++ b/components/schemas/Metafields-Values.yaml
@@ -1,0 +1,10 @@
+title: Metafields Values
+type: object
+patternProperties:
+  "^.*$":
+    description: key-value pairs of custom metafield names and values
+    type: string
+additionalProperties: false
+example:
+  custom_field_name_1: "custom_field_value_1"
+  custom_field_name_2: "custom_field_value_2"

--- a/components/schemas/Metafields-Values.yaml
+++ b/components/schemas/Metafields-Values.yaml
@@ -1,8 +1,8 @@
 title: Metafields Values
 type: object
 patternProperties:
-  "^.*$":
-    description: key-value pairs of custom metafield names and values
+  "^[a-zA-Z0-9_-]+$":
+    description: "(Optional) A set of key/value pairs representing custom fields and their values. Metafields will be created “on-the-fly” in your site for a given key, if they have not been created yet."
     type: string
 additionalProperties: false
 example:

--- a/components/schemas/Metafields.yaml
+++ b/components/schemas/Metafields.yaml
@@ -1,4 +1,0 @@
-title: Metafields
-description: A set of key/value pairs representing custom fields and their values.
-additionalProperties:
-  type: string

--- a/components/schemas/Payer-Attributes.yaml
+++ b/components/schemas/Payer-Attributes.yaml
@@ -36,4 +36,4 @@ properties:
   tax_exempt_reason:
     type: string
   metafields:
-    type: object
+    $ref: "./Metafields-Values.yaml"

--- a/components/schemas/Subscription-Group-Signup-Item.yaml
+++ b/components/schemas/Subscription-Group-Signup-Item.yaml
@@ -39,4 +39,4 @@ properties:
   calendar_billing:
     $ref: "./Calendar-Billing.yaml"
   metafields:
-    type: object
+    $ref: "./Metafields-Values.yaml"


### PR DESCRIPTION
### corresponding JIRA ticket:
https://maxioevolution.atlassian.net/browse/PAYM-757

### Affected URLs
`POST /subscription_groups/signup.json`

### Why
Documentation did not define how to pass metafield values in Payer Attributes in affected call

### What
- definition added
- enum of Metafield input types updated in the docs to be congruent with backend-defined values

<img width="330" alt="Screenshot 2023-09-28 at 14 06 45" src="https://github.com/maxio-com/stoplight-platform-api-docs/assets/142793346/a7ec279f-9253-437a-93ba-7360bdd874a0">


### Visual evidence

<img width="1113" alt="Screenshot 2023-09-29 at 22 26 40" src="https://github.com/maxio-com/stoplight-platform-api-docs/assets/142793346/a0705a0b-fffc-4f79-bd31-9573af3fba46">

<img width="841" alt="Screenshot 2023-09-29 at 22 05 58" src="https://github.com/maxio-com/stoplight-platform-api-docs/assets/142793346/7f00d5cc-1ec7-4be6-a1f2-de3b30467f80">


<img width="631" alt="Screenshot 2023-09-29 at 22 26 48" src="https://github.com/maxio-com/stoplight-platform-api-docs/assets/142793346/1545bd51-9621-4a01-8ea6-a8a36fbcdc23">

<img width="678" alt="Screenshot 2023-09-29 at 22 27 45" src="https://github.com/maxio-com/stoplight-platform-api-docs/assets/142793346/03c5b628-07e7-4d5d-9054-bbc2378b2816">


