### PR TITLE
Remove errors and warnings for Events paths

### DIFF
--- a/reference/Chargify-API.v1.yaml
+++ b/reference/Chargify-API.v1.yaml
@@ -1233,7 +1233,7 @@ paths:
           in: query
           name: auto_invite
           description: |-
-            When set to 1, an Invitation email will be sent to the Customer. 
+            When set to 1, an Invitation email will be sent to the Customer.
             When set to 0, or not sent, an email will not be sent.
             Use in query: `auto_invite=1`.
   "/portal/customers/{customer_id}/management_link.json":
@@ -3136,7 +3136,9 @@ paths:
                           new_subscription_state: past_due
             application/xml:
               schema:
-                type: object
+                type: array
+                items:
+                  $ref: "../components/schemas/Event-Response.yaml"
             multipart/form-data:
               schema:
                 type: array
@@ -3212,10 +3214,12 @@ paths:
             type: integer
           in: query
           name: since_id
+          description: Returns events with an id greater than or equal to the one specified
         - schema:
             type: integer
           in: query
           name: max_id
+          description: Returns events with an id less than or equal to the one specified
         - schema:
             type: string
             enum:
@@ -3224,6 +3228,7 @@ paths:
             default: desc
           in: query
           name: direction
+          description: The sort direction of the returned events.
         - $ref: "../components/parameters/event-type-filter.yaml"
         - schema:
             $ref: "../components/schemas/List-Events-Date-Field.yaml"
@@ -3306,10 +3311,12 @@ paths:
             type: integer
           in: query
           name: since_id
+          description: Returns events with an id greater than or equal to the one specified
         - schema:
             type: integer
           in: query
           name: max_id
+          description: Returns events with an id less than or equal to the one specified
         - schema:
             type: string
             enum:
@@ -3318,6 +3325,7 @@ paths:
             default: desc
           in: query
           name: direction
+          description: The sort direction of the returned events.
         - $ref: "../components/parameters/event-type-filter.yaml"
   /events/count.json:
     get:
@@ -3343,10 +3351,12 @@ paths:
             type: integer
           in: query
           name: since_id
+          description: Returns events with an id greater than or equal to the one specified
         - schema:
             type: integer
           in: query
           name: max_id
+          description: Returns events with an id less than or equal to the one specified
         - schema:
             type: string
             enum:
@@ -3355,6 +3365,7 @@ paths:
             default: desc
           in: query
           name: direction
+          description: The sort direction of the returned events.
         - $ref: "../components/parameters/event-type-filter.yaml"
       description: Get a count of all the events for a given site by using this method.
   /mrr.json:
@@ -10504,7 +10515,7 @@ paths:
         It is possible to provide a proof of customer's acceptance of terms and policies.
         We will be storing this proof in case it might be required (i.e. chargeback).
         Currently, we already keep it for subscriptions created via Public Signup Pages.
-        In order to create a subscription with the proof of agreement acceptance, you must provide additional parameters `agreement acceptance` with `ip_address` and at least one url to the policy that was accepted: `terms_url` or `privacy_policy_url`. Additional urls that can be provided: `return_refund_policy_url`, `delivery_policy_url` and 
+        In order to create a subscription with the proof of agreement acceptance, you must provide additional parameters `agreement acceptance` with `ip_address` and at least one url to the policy that was accepted: `terms_url` or `privacy_policy_url`. Additional urls that can be provided: `return_refund_policy_url`, `delivery_policy_url` and
         `secure_checkout_policy_url`.
 
         ```json
@@ -11069,11 +11080,13 @@ paths:
         name: subdomain
         in: path
         required: true
+        description: Your site's subdomain
       - schema:
           type: string
         name: api_handle
         in: path
         required: true
+        description: Identifies the Stream for which the events should be published.
     post:
       summary: Bulk Event Ingestion
       tags:
@@ -13580,7 +13593,7 @@ paths:
                 "quantity": 1
               }
             ],
-            "coupons": [ 
+            "coupons": [
               {
                 "code": "COUPONCODE",
                 "percentage": 50.0
@@ -13593,7 +13606,7 @@ paths:
 
         ```json
         ...
-         "coupons": [ 
+         "coupons": [
               {
                 "code": "FREESETUP",
                 "product_family_id": 1
@@ -13607,12 +13620,12 @@ paths:
         Coupon `code` will be displayed on invoice discount section.
         Coupon code can only contain uppercase letters, numbers, and allowed special characters.
         Lowercase letters will be converted to uppercase. It can be used to select an existing coupon from the catalog, or as an ad hoc coupon when passed with `percentage` or `amount`.
-        #### Percentage 
+        #### Percentage
         Coupon `percentage` can take values from 0 to 100 and up to 4 decimal places. It cannot be used with `amount`. Only for ad hoc coupons, will be ignored if `code` is used to select an existing coupon from the catalog.
         #### Amount
-        Coupon `amount` takes number value. It cannot be used with `percentage`. Used only when not matching existing coupon by `code`. 
+        Coupon `amount` takes number value. It cannot be used with `percentage`. Used only when not matching existing coupon by `code`.
         #### Description
-        Optional `description` will be displayed with coupon `code`. Used only when not matching existing coupon by `code`. 
+        Optional `description` will be displayed with coupon `code`. Used only when not matching existing coupon by `code`.
         #### Product Family id
         Optional `product_family_id` handle (with handle: prefix) or id is used to match existing coupon within site, when codes are not unique.
         #### Compounding Strategy
@@ -13624,7 +13637,7 @@ paths:
         Percentage-based discounts will be calculated against the remaining price, after prior discounts have been calculated. It is set by default.
 
         `full-price` strategy:
-        Percentage-based discounts will always be calculated against the original item price, before other discounts are applied. 
+        Percentage-based discounts will always be calculated against the original item price, before other discounts are applied.
 
         ### Line Item Options
 
@@ -14994,7 +15007,7 @@ paths:
         * `"parent"` which indicates the subscription will be paid for by the subscribing customer's parent within a customer hierarchy, or
         * `"eldest"` which indicates the subscription will be paid for by the root-level customer in the subscribing customer's hierarchy.
 
-        To create a new subscription into a subscription group, please reference the following: 
+        To create a new subscription into a subscription group, please reference the following:
         [Create Subscription in a Subscription Group](https://developers.chargify.com/docs/api-docs/d571659cf0f24-create-subscription#subscription-in-a-subscription-group)
       requestBody:
         content:
@@ -17410,11 +17423,11 @@ paths:
 
         For details on how the activation works, and how to activate subscriptions through the application, see [activation](#).
 
-        The `revert_on_failure` parameter controls the behavior upon activation failure. 
-        - If set to `true` and something goes wrong i.e. payment fails, then Chargify will not change the subscription's state. The subscription’s billing period will also remain the same. 
+        The `revert_on_failure` parameter controls the behavior upon activation failure.
+        - If set to `true` and something goes wrong i.e. payment fails, then Chargify will not change the subscription's state. The subscription’s billing period will also remain the same.
         - If set to `false` and something goes wrong i.e. payment fails, then Chargify will continue through with the activation and enter an end of life state. For trialing subscriptions, that will either be trial ended (if the trial is no obligation), past due (if the trial has an obligation), or canceled (if the site has no dunning strategy, or has a strategy that says to cancel immediately). For awaiting signup subscriptions, that will always be canceled.
 
-        The default activation failure behavior can be configured per activation attempt, or you may set a default value under Config > Settings > Subscription Activation Settings. 
+        The default activation failure behavior can be configured per activation attempt, or you may set a default value under Config > Settings > Subscription Activation Settings.
 
         ## Activation Scenarios
 


### PR DESCRIPTION
WHAT?
Use ref in the schema property for the `/events.xml` response. Add some missing descriptions to the parameters for various Events paths.