### PR TITLE
[documentation] PAYM-829 fixing errors and warnings related to prepaym.

### DIFF
--- a/components/schemas/Base-Refund-Error.yaml
+++ b/components/schemas/Base-Refund-Error.yaml
@@ -1,0 +1,7 @@
+title: Base Refund Error
+type: object
+properties:
+  base:
+    type: array
+    items:
+      type: object

--- a/components/schemas/No-Content.yaml
+++ b/components/schemas/No-Content.yaml
@@ -1,6 +1,3 @@
 title: No Content
 type: string
 description: Empty content
-examples:
-  Example:
-    value: ''

--- a/components/schemas/No-Content.yaml
+++ b/components/schemas/No-Content.yaml
@@ -1,0 +1,4 @@
+title: No Content
+type: object
+nullable: true
+description: Empty content

--- a/components/schemas/No-Content.yaml
+++ b/components/schemas/No-Content.yaml
@@ -1,4 +1,6 @@
 title: No Content
-type: object
-nullable: true
+type: string
 description: Empty content
+examples:
+  Example:
+    value: ''

--- a/components/schemas/Prepayments-Response.yaml
+++ b/components/schemas/Prepayments-Response.yaml
@@ -1,0 +1,8 @@
+title: Prepayments Response
+type: object
+properties:
+  prepayments:
+    type: array
+    uniqueItems: true
+    items:
+      $ref: "./Prepayment.yaml"

--- a/components/schemas/Refund-Prepayment-Aggregated-Error.yaml
+++ b/components/schemas/Refund-Prepayment-Aggregated-Error.yaml
@@ -1,0 +1,5 @@
+title: Refund Prepayment Aggregated Error
+type: object
+properties:
+  refund:
+    $ref: "./Refund-Prepayment-Error.yaml"

--- a/components/schemas/Refund-Prepayment-Aggregated-Errors-Response.yaml
+++ b/components/schemas/Refund-Prepayment-Aggregated-Errors-Response.yaml
@@ -3,26 +3,10 @@ description: Errors returned on creating a refund prepayment, grouped by field, 
 type: object
 properties:
   errors:
-    type: object
-    properties:
+    $ref: "./Refund-Prepayment-Aggregated-Error.yaml"
+examples:
+  Example:
+    errors:
       refund:
-        type: object
-        properties:
-          amount_in_cents:
-            type: array
-            items:
-              type: string
-          base:
-            type: array
-            items:
-              type: string
-          external:
-            type: array
-            items:
-              type: string
-x-examples:
-  example-1:
-    refund:
-      errors:
         amount_in_cents:
           - Refund amount exceeds prepayment amount

--- a/components/schemas/Refund-Prepayment-Aggregated-Errors-Response.yaml
+++ b/components/schemas/Refund-Prepayment-Aggregated-Errors-Response.yaml
@@ -1,0 +1,28 @@
+title: Refund Prepayment Aggregated Errors Response
+description: Errors returned on creating a refund prepayment, grouped by field, as arrays of strings.
+type: object
+properties:
+  errors:
+    type: object
+    properties:
+      refund:
+        type: object
+        properties:
+          amount_in_cents:
+            type: array
+            items:
+              type: string
+          base:
+            type: array
+            items:
+              type: string
+          external:
+            type: array
+            items:
+              type: string
+x-examples:
+  example-1:
+    refund:
+      errors:
+        amount_in_cents:
+          - Refund amount exceeds prepayment amount

--- a/components/schemas/Refund-Prepayment-Aggregated-Errors-Response.yaml
+++ b/components/schemas/Refund-Prepayment-Aggregated-Errors-Response.yaml
@@ -4,9 +4,3 @@ type: object
 properties:
   errors:
     $ref: "./Refund-Prepayment-Aggregated-Error.yaml"
-examples:
-  Example:
-    errors:
-      refund:
-        amount_in_cents:
-          - Refund amount exceeds prepayment amount

--- a/components/schemas/Refund-Prepayment-Base-Errors-Response.yaml
+++ b/components/schemas/Refund-Prepayment-Base-Errors-Response.yaml
@@ -3,17 +3,9 @@ description: Errors returned on creating a refund prepayment when bad request
 type: object
 properties:
   errors:
-    type: object
-    properties:
-      refund:
-        type: object
-        properties:
-          base:
-            type: array
-            items:
-              type: object
-x-examples:
-  example-1:
+    $ref: "./Refund-Prepayment-Base-Refund-Error.yaml"
+examples:
+  Example:
     errors:
       refund:
         base:

--- a/components/schemas/Refund-Prepayment-Base-Errors-Response.yaml
+++ b/components/schemas/Refund-Prepayment-Base-Errors-Response.yaml
@@ -4,9 +4,3 @@ type: object
 properties:
   errors:
     $ref: "./Refund-Prepayment-Base-Refund-Error.yaml"
-examples:
-  Example:
-    errors:
-      refund:
-        base:
-          - must be an object

--- a/components/schemas/Refund-Prepayment-Base-Errors-Response.yaml
+++ b/components/schemas/Refund-Prepayment-Base-Errors-Response.yaml
@@ -1,0 +1,20 @@
+title: Refund Prepayment Base Errors Response
+description: Errors returned on creating a refund prepayment when bad request
+type: object
+properties:
+  errors:
+    type: object
+    properties:
+      refund:
+        type: object
+        properties:
+          base:
+            type: array
+            items:
+              type: object
+x-examples:
+  example-1:
+    errors:
+      refund:
+        base:
+          - must be an object

--- a/components/schemas/Refund-Prepayment-Base-Refund-Error.yaml
+++ b/components/schemas/Refund-Prepayment-Base-Refund-Error.yaml
@@ -1,0 +1,5 @@
+title: Refund Prepayment Base Refund Error
+type: object
+properties:
+  refund:
+    $ref: "./Base-Refund-Error.yaml"

--- a/components/schemas/Refund-Prepayment-Error.yaml
+++ b/components/schemas/Refund-Prepayment-Error.yaml
@@ -1,0 +1,15 @@
+title: Prepayment Aggregated Error
+type: object
+properties:
+  amount_in_cents:
+    type: array
+    items:
+      type: string
+  base:
+    type: array
+    items:
+      type: string
+  external:
+    type: array
+    items:
+      type: string

--- a/reference/Chargify-API.v1.yaml
+++ b/reference/Chargify-API.v1.yaml
@@ -13749,13 +13749,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  prepayments:
-                    type: array
-                    uniqueItems: true
-                    items:
-                      $ref: "../components/schemas/Prepayment.yaml"
+                $ref: "../components/schemas/Prepayments-Response.yaml"
               examples:
                 example-success-response:
                   value:
@@ -16697,71 +16691,19 @@ paths:
           content:
             application/json:
               schema:
-                description: ""
-                type: object
-                x-examples:
-                  example-1:
-                    errors:
-                      refund:
-                        base:
-                          - must be an object
-                properties:
-                  errors:
-                    type: object
-                    properties:
-                      refund:
-                        type: object
-                        properties:
-                          base:
-                            type: array
-                            items:
-                              type: object
+                $ref: "../components/schemas/Refund-Prepayment-Base-Errors-Response.yaml"
         "404":
           description: Not Found
           content:
             application/json:
               schema:
-                type: object
-                properties: {}
+                $ref: "../components/schemas/No-Content.yaml"
         "422":
-          description: Unprocessable Entity (WebDAV)
+          description: Unprocessable Entity
           content:
             application/json:
               schema:
-                description: ""
-                type: object
-                x-examples:
-                  example-1:
-                    refund:
-                      errors:
-                        amount_in_cents:
-                          - Refund amount exceeds prepayment amount
-                properties:
-                  errors:
-                    type: object
-                    properties:
-                      refund:
-                        type: object
-                        properties:
-                          amount_in_cents:
-                            type: array
-                            items:
-                              type: string
-                          base:
-                            type: array
-                            items:
-                              type: string
-                          external:
-                            type: array
-                            items:
-                              type: string
-              examples:
-                Example Error:
-                  value:
-                    errors:
-                      refund:
-                        amount_in_cents:
-                          - Refund amount exceeds prepayment amount
+                $ref: "../components/schemas/Refund-Prepayment-Aggregated-Errors-Response.yaml"
       operationId: refundPrepayment
       description: |-
         This endpoint will refund, completely or partially, a particular prepayment applied to a subscription. The `prepayment_id` will be the account transaction ID of the original payment. The prepayment must have some amount remaining in order to be refunded.

--- a/reference/Chargify-API.v1.yaml
+++ b/reference/Chargify-API.v1.yaml
@@ -6588,6 +6588,7 @@ paths:
       - schema:
           type: integer
         name: bank_account_id
+        description: Identifier of the bank account in the system.
         in: path
         required: true
     put:
@@ -16698,12 +16699,22 @@ paths:
             application/json:
               schema:
                 $ref: "../components/schemas/No-Content.yaml"
+              examples:
+                Example:
+                  value: ""
         "422":
           description: Unprocessable Entity
           content:
             application/json:
               schema:
                 $ref: "../components/schemas/Refund-Prepayment-Aggregated-Errors-Response.yaml"
+              examples:
+                Example:
+                  value:
+                    errors:
+                      refund:
+                        amount_in_cents:
+                          - Refund amount exceeds prepayment amount
       operationId: refundPrepayment
       description: |-
         This endpoint will refund, completely or partially, a particular prepayment applied to a subscription. The `prepayment_id` will be the account transaction ID of the original payment. The prepayment must have some amount remaining in order to be refunded.


### PR DESCRIPTION
Collection Method unification

## Corresponding JIRA Ticket
https://maxioevolution.atlassian.net/browse/PAYM-829

## What

- $refs added where needed
- 404 in fact even with `application/json` returns not empty json object but a "no-content", blank string. 
checked how to model it in line with OpenAPI 3.0 specs and added a file for it.


![Screenshot 2023-10-10 at 14 30 29](https://github.com/maxio-com/stoplight-platform-api-docs/assets/142793346/d46ac3ed-94cd-4811-9ae7-17fa72497529)
![Screenshot 2023-10-10 at 15 02 13](https://github.com/maxio-com/stoplight-platform-api-docs/assets/142793346/5cbf1f6a-be43-4a2b-b0f1-e89463ee9431)
![Screenshot 2023-10-10 at 15 02 21](https://github.com/maxio-com/stoplight-platform-api-docs/assets/142793346/8d2c9272-82f7-4e4b-bec2-c26d927c1f40)

