### PR TITLE
[bug] Update the Purge Subscriptions document that the customer ID is required in the URL to successfully process a purging

### DIFF
--- a/reference/Chargify-API.v1.yaml
+++ b/reference/Chargify-API.v1.yaml
@@ -14839,6 +14839,7 @@ paths:
           in: query
           name: ack
           description: id of the customer.
+          required: true
         - schema:
             type: array
             items:


### PR DESCRIPTION
**WHAT?**
Mark the `ack` param as required