### PR TITLE
[DE-541] Fix payment profiles

### DIFF
--- a/components/schemas/Create-Payment-Profile.yaml
+++ b/components/schemas/Create-Payment-Profile.yaml
@@ -93,3 +93,10 @@ properties:
   bank_branch_code:
     type: string
     description: "(Optional when creating with GoCardless, required with Stripe BECS Direct Debit) Branch code. Alternatively, an IBAN can be provided"
+  bank_account_type:
+    type: string
+  bank_account_holder_type:
+    type: string
+  last_four:
+    type: string
+    description: "(Optional) Used for creating subscription with payment profile imported using vault_token, for proper display in Advanced Billing UI"

--- a/components/schemas/Updated-Payment-Profile.yaml
+++ b/components/schemas/Updated-Payment-Profile.yaml
@@ -42,4 +42,6 @@ properties:
   masked_card_number:
     type: string
   customer_vault_token:
-    type: string
+    type:
+      - string
+      - "null"

--- a/components/schemas/Updated-Payment-Profile.yaml
+++ b/components/schemas/Updated-Payment-Profile.yaml
@@ -21,6 +21,8 @@ properties:
     type: string
   billing_address:
     type: string
+  billing_address_2:
+    type: string
   billing_city:
     type: string
   billing_state:
@@ -37,3 +39,7 @@ properties:
     type:
       - string
       - "null"
+  masked_card_number:
+    type: string
+  customer_vault_token:
+    type: string

--- a/reference/Chargify-API.v1.yaml
+++ b/reference/Chargify-API.v1.yaml
@@ -5928,7 +5928,6 @@ paths:
                     payment_profile:
                       first_name: Jessica
                       last_name: Test
-                      last_four: "1111"
                       card_type: visa
                       expiration_month: 10
                       expiration_year: 2018
@@ -6530,7 +6529,6 @@ paths:
                     expiration_month: "04"
                     expiration_year: "2030"
                     current_vault: bogus
-                    vault_token: "1"
                     billing_address: 456 Juniper Court
                     billing_city: Boulder
                     billing_state: CO


### PR DESCRIPTION
Fix payment profiles,
updated-payment-profile is very similar to payment-profile, maybe they can be merged? payment-profile in addition has only `chargify_token`, but I didn't even see this field while calling GET payment_profile.
Also, updated-payment-profile doesn't have fields for bank account, but I think bank account can be updated with that endpoint, we can check that.  