### PR TITLE
[DE-600] Deduplicate prepayment names

### DIFF
--- a/components/schemas/Invoice-Prepayment.yaml
+++ b/components/schemas/Invoice-Prepayment.yaml
@@ -1,4 +1,4 @@
-title: Pre-Payment
+title: Invoice PrePayment
 type: object
 properties:
   subscription_id:

--- a/components/schemas/Metafield.yaml
+++ b/components/schemas/Metafield.yaml
@@ -15,6 +15,7 @@ properties:
   enum:
     oneOf:
       - type: "null"
+      - type: string
       - type: array
         items:
           type: string

--- a/components/schemas/Payment-Response.yaml
+++ b/components/schemas/Payment-Response.yaml
@@ -6,4 +6,4 @@ properties:
     items:
       $ref: "./Payment.yaml"
   prepayment:
-    $ref: "./Pre-Payment.yaml"
+    $ref: "./Invoice-Prepayment.yaml"


### PR DESCRIPTION
Before, generated SDKs had class names like `Prepayment` and `Prepayment1`

Also, added string to metafield enum types