### PR TITLE
[DE-634] Unify upgrade_charge and downgrade_credit

### DIFF
--- a/components/schemas/Allocate-Components.yaml
+++ b/components/schemas/Allocate-Components.yaml
@@ -18,9 +18,9 @@ properties:
   accrue_charge:
     type: boolean
   upgrade_charge:
-    type: string
+    $ref: "./Credit-Type.yaml"
   downgrade_credit:
-    type: string
+    $ref: "./Credit-Type.yaml"
   payment_collection_method:
     $ref: "./Collection-Method.yaml"
     description: "(Optional) If not passed, the allocation(s) will use the payment collection method on the subscription"

--- a/components/schemas/Allocation-Preview-Item.yaml
+++ b/components/schemas/Allocation-Preview-Item.yaml
@@ -22,9 +22,9 @@ properties:
   accrue_charge:
     type: boolean
   upgrade_charge:
-    type: string
+    $ref: "./Credit-Type.yaml"
   downgrade_credit:
-    type: string
+    $ref: "./Credit-Type.yaml"
   price_point_id:
     type: integer
   previous_price_point_id:

--- a/components/schemas/Allocation-Settings.yaml
+++ b/components/schemas/Allocation-Settings.yaml
@@ -2,12 +2,8 @@ title: Allocation Settings
 type: object
 properties:
   upgrade_charge:
-    type:
-      - string
-      - "null"
+    $ref: "./Credit-Type.yaml"
   downgrade_credit:
-    type:
-      - string
-      - "null"
+    $ref: "./Credit-Type.yaml"
   accrue_charge:
     type: boolean

--- a/components/schemas/Allocation.yaml
+++ b/components/schemas/Allocation.yaml
@@ -39,11 +39,9 @@ properties:
     type: boolean
     description: "If the change in cost is an upgrade, this determines if the charge should accrue to the next renewal or if capture should be attempted immediately."
   upgrade_charge:
-    type: string
-    description: The type of charge to be created if the change in cost is an upgrade.
+    $ref: "./Credit-Type.yaml"
   downgrade_credit:
-    type: string
-    description: The type of credit to be created if the change in cost is a downgrade.
+    $ref: "./Credit-Type.yaml"
   payment:
     oneOf:
       - type: "null"

--- a/components/schemas/Component.yaml
+++ b/components/schemas/Component.yaml
@@ -75,13 +75,9 @@ properties:
   recurring:
     type: boolean
   upgrade_charge:
-    type:
-      - string
-      - "null"
+    $ref: "./Credit-Type.yaml"
   downgrade_credit:
-    type:
-      - string
-      - "null"
+    $ref: "./Credit-Type.yaml"
   created_at:
     type: string
     description: Timestamp indicating when this component was created

--- a/components/schemas/Create-Allocation.yaml
+++ b/components/schemas/Create-Allocation.yaml
@@ -22,13 +22,9 @@ properties:
     type: boolean
     description: "If the change in cost is an upgrade, this determines if the charge should accrue to the next renewal or if capture should be attempted immediately. Defaults to the site setting if one is not provided."
   downgrade_credit:
-    allOf:
-      - $ref: "./Credit-Type.yaml"
-    description: The type of credit to be created if the change in cost is a downgrade. Defaults to the component and then site setting if one is not provided.
+    $ref: "./Credit-Type.yaml"
   upgrade_charge:
-    allOf:
-      - $ref: "./Credit-Type.yaml"
-    description: The type of charge to be created if the change in cost is an upgrade. Defaults to the component and then site setting if one is not provided.
+    $ref: "./Credit-Type.yaml"
   price_point_id:
     type:
       - string

--- a/components/schemas/Credit-Type.yaml
+++ b/components/schemas/Credit-Type.yaml
@@ -1,5 +1,7 @@
 title: Credit Type
-type: string
+type:
+  - string
+  - "null"
 description: |-
   The type of credit to be created when upgrading/downgrading. Defaults to the component and then site setting if one is not provided.
   Available values: `full`, `prorated`, `none`.
@@ -7,3 +9,4 @@ enum:
   - full
   - prorated
   - none
+  - null

--- a/components/schemas/Ebb-Component.yaml
+++ b/components/schemas/Ebb-Component.yaml
@@ -25,9 +25,9 @@ properties:
     items:
       $ref: "./Price.yaml"
   upgrade_charge:
-    type: string
+    $ref: "./Credit-Type.yaml"
   downgrade_credit:
-    type: string
+    $ref: "./Credit-Type.yaml"
   price_points:
     type: array
     items:

--- a/components/schemas/Metered-Component.yaml
+++ b/components/schemas/Metered-Component.yaml
@@ -25,9 +25,9 @@ properties:
     items:
       $ref: "./Price.yaml"
   upgrade_charge:
-    type: string
+    $ref: "./Credit-Type.yaml"
   downgrade_credit:
-    type: string
+    $ref: "./Credit-Type.yaml"
   price_points:
     type: array
     items:

--- a/components/schemas/On-Off-Component.yaml
+++ b/components/schemas/On-Off-Component.yaml
@@ -25,9 +25,9 @@ properties:
     items:
       $ref: "./Price.yaml"
   upgrade_charge:
-    type: string
+    $ref: "./Credit-Type.yaml"
   downgrade_credit:
-    type: string
+    $ref: "./Credit-Type.yaml"
   price_points:
     type: array
     items:

--- a/components/schemas/Prepaid-Component.yaml
+++ b/components/schemas/Prepaid-Component.yaml
@@ -25,9 +25,9 @@ properties:
     items:
       $ref: "./Price.yaml"
   upgrade_charge:
-    type: string
+    $ref: "./Credit-Type.yaml"
   downgrade_credit:
-    type: string
+    $ref: "./Credit-Type.yaml"
   price_points:
     type: array
     items:

--- a/components/schemas/Quantity-Based-Component.yaml
+++ b/components/schemas/Quantity-Based-Component.yaml
@@ -25,9 +25,9 @@ properties:
     items:
       $ref: "./Price.yaml"
   upgrade_charge:
-    type: string
+    $ref: "./Credit-Type.yaml"
   downgrade_credit:
-    type: string
+    $ref: "./Credit-Type.yaml"
   price_points:
     type: array
     items:

--- a/components/schemas/Subscription-Component.yaml
+++ b/components/schemas/Subscription-Component.yaml
@@ -34,13 +34,9 @@ properties:
   recurring:
     type: boolean
   upgrade_charge:
-    type:
-      - string
-      - "null"
+    $ref: "./Credit-Type.yaml"
   downgrade_credit:
-    type:
-      - string
-      - "null"
+    $ref: "./Credit-Type.yaml"
   archived_at:
     type:
       - "null"

--- a/components/schemas/Update-Component.yaml
+++ b/components/schemas/Update-Component.yaml
@@ -27,4 +27,3 @@ properties:
     type: boolean
   upgrade_charge:
     $ref: "./Credit-Type.yaml"
-    description: "The type of charge to be applied when a component is upgraded. Valid values are: `prorated`, `full`, `none`."


### PR DESCRIPTION
Question to the subscription team: is it valid to assume that all these properties can be only `prorated`, `full`, or `none`?