### PR TITLE
missing prepaid component kind

### DIFF
--- a/components/schemas/Line-Item-Kind.yaml
+++ b/components/schemas/Line-Item-Kind.yaml
@@ -6,6 +6,7 @@ enum:
   - initial
   - trial
   - quantity_based_component
+  - prepaid_usage_component
   - on_off_component
   - metered_component
   - event_based_component


### PR DESCRIPTION
added missing kind for prepaid_component:
![Screenshot 2024-01-05 at 14 14 25](https://github.com/maxio-com/stoplight-platform-api-docs/assets/623118/35e4540b-2d88-4457-b408-37e099866966)
