### PR TITLE
[bugfix] Fix amount_in_cents range for included coupons array in Subscriptions API docs

### DIFF
--- a/components/schemas/Subscription-Included-Coupon.yaml
+++ b/components/schemas/Subscription-Included-Coupon.yaml
@@ -22,7 +22,7 @@ properties:
       - integer
       - "null"
     format: int64
-    minimum: 1
+    minimum: 0
     example: 1000
   percentage:
     type:

--- a/components/schemas/Subscription-Included-Coupon.yaml
+++ b/components/schemas/Subscription-Included-Coupon.yaml
@@ -22,6 +22,7 @@ properties:
       - integer
       - "null"
     format: int64
+    minimum: 1
     example: 1000
   percentage:
     type:


### PR DESCRIPTION
**WHAT?**
Fix amount_in_cents range for included coupons array in Subscriptions API docs

**HOW?**
Use `minimum` option and set it to `0`.