### PR TITLE
Set memo as nullable

### DIFF
--- a/components/schemas/invoice_event_specific_data/Apply-Credit-Note-Event-Data.yaml
+++ b/components/schemas/invoice_event_specific_data/Apply-Credit-Note-Event-Data.yaml
@@ -22,7 +22,9 @@ properties:
     format: date-time
     description: The time the credit note was applied, in ISO 8601 format, i.e. "2019-06-07T17:20:06Z"
   memo:
-    type: string
+    type:
+      - string
+      - "null"
     description: The credit note memo.
   role:
     type: string

--- a/components/schemas/invoice_event_specific_data/Apply-Debit-Note-Event-Data.yaml
+++ b/components/schemas/invoice_event_specific_data/Apply-Debit-Note-Event-Data.yaml
@@ -15,10 +15,14 @@ properties:
     type: string
     description: The amount of the debit note applied to invoice.
   memo:
-    type: string
+    type:
+      - string
+      - "null"
     description: The debit note memo.
   transaction_time:
-    type: string
+    type:
+      - string
+      - "null"
     description: The time the debit note was applied, in ISO 8601 format, i.e. "2019-06-07T17:20:06Z"
 required:
   - debit_note_number

--- a/components/schemas/invoice_event_specific_data/Apply-Debit-Note-Event-Data.yaml
+++ b/components/schemas/invoice_event_specific_data/Apply-Debit-Note-Event-Data.yaml
@@ -23,6 +23,7 @@ properties:
     type:
       - string
       - "null"
+    format: date-time
     description: The time the debit note was applied, in ISO 8601 format, i.e. "2019-06-07T17:20:06Z"
 required:
   - debit_note_number

--- a/components/schemas/invoice_event_specific_data/Failed-Payment-Event-Data.yaml
+++ b/components/schemas/invoice_event_specific_data/Failed-Payment-Event-Data.yaml
@@ -9,7 +9,9 @@ properties:
     type: integer
     description: The monetary value of the payment, expressed in dollars.
   memo:
-    type: string
+    type:
+      - string
+      - "null"
     description: The memo passed when the payment was created.
   payment_method:
     $ref: "../Invoice-Payment-Method-Type.yaml"

--- a/portal/spec/components/schemas/invoice_event_specific_data/Apply-Credit-Note-Event-Data.yaml
+++ b/portal/spec/components/schemas/invoice_event_specific_data/Apply-Credit-Note-Event-Data.yaml
@@ -22,7 +22,9 @@ properties:
     format: date-time
     description: The time the credit note was applied, in ISO 8601 format, i.e. "2019-06-07T17:20:06Z"
   memo:
-    type: ["string", "null"]
+    type:
+      - string
+      - "null"
     description: The credit note memo.
   role:
     type: string

--- a/portal/spec/components/schemas/invoice_event_specific_data/Apply-Credit-Note-Event-Data.yaml
+++ b/portal/spec/components/schemas/invoice_event_specific_data/Apply-Credit-Note-Event-Data.yaml
@@ -22,7 +22,7 @@ properties:
     format: date-time
     description: The time the credit note was applied, in ISO 8601 format, i.e. "2019-06-07T17:20:06Z"
   memo:
-    type: string
+    type: ["string", "null"]
     description: The credit note memo.
   role:
     type: string

--- a/portal/spec/components/schemas/invoice_event_specific_data/Apply-Debit-Note-Event-Data.yaml
+++ b/portal/spec/components/schemas/invoice_event_specific_data/Apply-Debit-Note-Event-Data.yaml
@@ -15,10 +15,10 @@ properties:
     type: string
     description: The amount of the debit note applied to invoice.
   memo:
-    type: string
+    type: ["string", "null"]
     description: The debit note memo.
   transaction_time:
-    type: string
+    type: ["string", "null"]
     description: The time the debit note was applied, in ISO 8601 format, i.e. "2019-06-07T17:20:06Z"
 required:
   - debit_note_number

--- a/portal/spec/components/schemas/invoice_event_specific_data/Apply-Debit-Note-Event-Data.yaml
+++ b/portal/spec/components/schemas/invoice_event_specific_data/Apply-Debit-Note-Event-Data.yaml
@@ -23,6 +23,7 @@ properties:
     type:
       - string
       - "null"
+    format: date-time
     description: The time the debit note was applied, in ISO 8601 format, i.e. "2019-06-07T17:20:06Z"
 required:
   - debit_note_number

--- a/portal/spec/components/schemas/invoice_event_specific_data/Apply-Debit-Note-Event-Data.yaml
+++ b/portal/spec/components/schemas/invoice_event_specific_data/Apply-Debit-Note-Event-Data.yaml
@@ -15,10 +15,14 @@ properties:
     type: string
     description: The amount of the debit note applied to invoice.
   memo:
-    type: ["string", "null"]
+    type:
+      - string
+      - "null"
     description: The debit note memo.
   transaction_time:
-    type: ["string", "null"]
+    type:
+      - string
+      - "null"
     description: The time the debit note was applied, in ISO 8601 format, i.e. "2019-06-07T17:20:06Z"
 required:
   - debit_note_number

--- a/portal/spec/components/schemas/invoice_event_specific_data/Failed-Payment-Event-Data.yaml
+++ b/portal/spec/components/schemas/invoice_event_specific_data/Failed-Payment-Event-Data.yaml
@@ -9,7 +9,7 @@ properties:
     type: integer
     description: The monetary value of the payment, expressed in dollars.
   memo:
-    type: string
+    type: ["string", "null"]
     description: The memo passed when the payment was created.
   payment_method:
     allOf:

--- a/portal/spec/components/schemas/invoice_event_specific_data/Failed-Payment-Event-Data.yaml
+++ b/portal/spec/components/schemas/invoice_event_specific_data/Failed-Payment-Event-Data.yaml
@@ -9,7 +9,9 @@ properties:
     type: integer
     description: The monetary value of the payment, expressed in dollars.
   memo:
-    type: ["string", "null"]
+    type:
+      - string
+      - "null"
     description: The memo passed when the payment was created.
   payment_method:
     allOf:


### PR DESCRIPTION
For some events, the `memo` is optional. This PR updates the documentation to reflect that.