### PR TITLE
[DE-827] Set int64 for long query parameters, set int64 for invoice event id

### DIFF
--- a/components/schemas/Invoice-Event.yaml
+++ b/components/schemas/Invoice-Event.yaml
@@ -3,6 +3,7 @@ type: object
 properties:
   id:
     type: integer
+    format: int64
   event_type:
     $ref: "./Invoice-Event-Type.yaml"
   event_data:

--- a/portal/spec/components/schemas/Invoice-Event.yaml
+++ b/portal/spec/components/schemas/Invoice-Event.yaml
@@ -3,6 +3,7 @@ type: object
 properties:
   id:
     type: integer
+    format: int64
   event_type:
     $ref: "./Invoice-Event-Type.yaml"
   event_data:

--- a/portal/spec/openapi.yaml
+++ b/portal/spec/openapi.yaml
@@ -2896,11 +2896,13 @@ paths:
         - $ref: "./components/parameters/per-page.yaml"
         - schema:
             type: integer
+            format: int64
           in: query
           name: since_id
           description: Returns events with an id greater than or equal to the one specified
         - schema:
             type: integer
+            format: int64
           in: query
           name: max_id
           description: Returns events with an id less than or equal to the one specified
@@ -2996,11 +2998,13 @@ paths:
         - $ref: "./components/parameters/per-page.yaml"
         - schema:
             type: integer
+            format: int64
           in: query
           name: since_id
           description: Returns events with an id greater than or equal to the one specified
         - schema:
             type: integer
+            format: int64
           in: query
           name: max_id
           description: Returns events with an id less than or equal to the one specified
@@ -3038,11 +3042,13 @@ paths:
         - $ref: "./components/parameters/per-page.yaml"
         - schema:
             type: integer
+            format: int64
           in: query
           name: since_id
           description: Returns events with an id greater than or equal to the one specified
         - schema:
             type: integer
+            format: int64
           in: query
           name: max_id
           description: Returns events with an id less than or equal to the one specified
@@ -8053,6 +8059,7 @@ paths:
           description: The timestamp in a format `YYYY-MM-DD T HH:MM:SS Z`, or `YYYY-MM-DD`(in this case, it returns data from the beginning of the day). of the event from which you want to start the search. All the events before the `since_date` timestamp are not returned in the response.
         - schema:
             type: integer
+            format: int64
           in: query
           name: since_id
           description: The ID of the event from which you want to start the search(ID is not included. e.g. if ID is set to 2, then all events with ID 3 and more will be shown) This parameter is not used if since_date is defined.
@@ -10308,11 +10315,13 @@ paths:
       parameters:
         - schema:
             type: integer
+            format: int64
           in: query
           name: since_id
           description: Returns usages with an id greater than or equal to the one specified
         - schema:
             type: integer
+            format: int64
           in: query
           name: max_id
           description: Returns usages with an id less than or equal to the one specified

--- a/reference/Chargify-API.v1.yaml
+++ b/reference/Chargify-API.v1.yaml
@@ -3346,11 +3346,13 @@ paths:
         - $ref: "../components/parameters/per-page.yaml"
         - schema:
             type: integer
+            format: int64
           in: query
           name: since_id
           description: Returns events with an id greater than or equal to the one specified
         - schema:
             type: integer
+            format: int64
           in: query
           name: max_id
           description: Returns events with an id less than or equal to the one specified
@@ -3446,11 +3448,13 @@ paths:
         - $ref: "../components/parameters/per-page.yaml"
         - schema:
             type: integer
+            format: int64
           in: query
           name: since_id
           description: Returns events with an id greater than or equal to the one specified
         - schema:
             type: integer
+            format: int64
           in: query
           name: max_id
           description: Returns events with an id less than or equal to the one specified
@@ -3488,11 +3492,13 @@ paths:
         - $ref: "../components/parameters/per-page.yaml"
         - schema:
             type: integer
+            format: int64
           in: query
           name: since_id
           description: Returns events with an id greater than or equal to the one specified
         - schema:
             type: integer
+            format: int64
           in: query
           name: max_id
           description: Returns events with an id less than or equal to the one specified
@@ -8574,6 +8580,7 @@ paths:
           description: The timestamp in a format `YYYY-MM-DD T HH:MM:SS Z`, or `YYYY-MM-DD`(in this case, it returns data from the beginning of the day). of the event from which you want to start the search. All the events before the `since_date` timestamp are not returned in the response.
         - schema:
             type: integer
+            format: int64
           in: query
           name: since_id
           description: The ID of the event from which you want to start the search(ID is not included. e.g. if ID is set to 2, then all events with ID 3 and more will be shown) This parameter is not used if since_date is defined.
@@ -10853,11 +10860,13 @@ paths:
       parameters:
         - schema:
             type: integer
+            format: int64
           in: query
           name: since_id
           description: Returns usages with an id greater than or equal to the one specified
         - schema:
             type: integer
+            format: int64
           in: query
           name: max_id
           description: Returns usages with an id less than or equal to the one specified


### PR DESCRIPTION
invoice event id didn't exceed int range yet but probably it will in future (its at about 700kk, while int32 limit is 2,1kkk) so its better to fix it sooner than later