### PR TITLE
Product family handle can be used when creating a product

### DIFF
--- a/portal/spec/openapi.yaml
+++ b/portal/spec/openapi.yaml
@@ -6,7 +6,7 @@ info:
     email: support@chargify.com
   description: |-
 
-    Maxio Advanced Billing (formerly Chargify) provides an HTTP-based API that conforms to the principles of REST. 
+    Maxio Advanced Billing (formerly Chargify) provides an HTTP-based API that conforms to the principles of REST.
     One of the many reasons to use Advanced Billing is the immense feature set and surrounding community [client libraries](page:development-tools/client-libraries).
     The Maxio API returns JSON responses as the primary and recommended format, but XML is also provided as a backwards compatible option for Merchants who require it.
 
@@ -3694,7 +3694,7 @@ paths:
 
         Event-based components are similar to other component types, in that you define the component parameters (such as name and taxability) and the pricing. A key difference for the event-based component is that it must be attached to a metric. This is because the metric provides the component with the actual quantity used in computing what and how much will be billed each period for each subscription.
 
-        So, instead of reporting usage directly for each component (as you would with metered components), the usage is derived from analysis of your events. 
+        So, instead of reporting usage directly for each component (as you would with metered components), the usage is derived from analysis of your events.
 
         For more information on components, please see our documentation [here](https://maxio-chargify.zendesk.com/hc/en-us/articles/5405020625677).
       requestBody:
@@ -4942,11 +4942,11 @@ paths:
   "/product_families/{product_family_id}/products.json":
     parameters:
       - schema:
-          type: integer
+          type: string
         name: product_family_id
         in: path
         required: true
-        description: The Chargify id of the product family to which the product belongs
+        description: "Either the product family's id or its handle prefixed with `handle:`"
     post:
       summary: Create Product
       tags:

--- a/reference/Chargify-API.v1.yaml
+++ b/reference/Chargify-API.v1.yaml
@@ -5436,7 +5436,7 @@ paths:
   "/product_families/{product_family_id}/products.json":
     parameters:
       - schema:
-          type: integer
+          type: string
         name: product_family_id
         in: path
         required: true

--- a/reference/Chargify-API.v1.yaml
+++ b/reference/Chargify-API.v1.yaml
@@ -4145,7 +4145,7 @@ paths:
 
         Event-based components are similar to other component types, in that you define the component parameters (such as name and taxability) and the pricing. A key difference for the event-based component is that it must be attached to a metric. This is because the metric provides the component with the actual quantity used in computing what and how much will be billed each period for each subscription.
 
-        So, instead of reporting usage directly for each component (as you would with metered components), the usage is derived from analysis of your events. 
+        So, instead of reporting usage directly for each component (as you would with metered components), the usage is derived from analysis of your events.
 
         For more information on components, please see our documentation [here](https://maxio-chargify.zendesk.com/hc/en-us/articles/5405020625677).
       requestBody:
@@ -5440,7 +5440,7 @@ paths:
         name: product_family_id
         in: path
         required: true
-        description: The Chargify id of the product family to which the product belongs
+        description: "Either the product family's id or its handle prefixed with `handle:`"
     post:
       summary: Create Product
       tags:


### PR DESCRIPTION
SUB-3996

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Refined descriptions and documentation within the API specification for clarity.
  - Clarified the purpose of Maxio Advanced Billing (formerly Chargify).
  - Updated details on event-based components and product families.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->