### PR TITLE
[IN-3434] Document Read Component Price Point

### DIFF
--- a/portal/spec/openapi.yaml
+++ b/portal/spec/openapi.yaml
@@ -34,6 +34,7 @@ tags:
   - name: Billing Portal
   - name: Coupons
   - name: Components
+  - name: "Component: Price Points"
   - name: Customers
   - name: Custom Fields
   - name: Events
@@ -4144,7 +4145,7 @@ paths:
     put:
       summary: Promote Price Point to Default
       tags:
-        - Components
+        - "Component: Price Points"
       responses:
         "200":
           description: OK
@@ -4336,7 +4337,7 @@ paths:
     post:
       summary: Create Component Price Point
       tags:
-        - Components
+        - "Component: Price Points"
       responses:
         "200":
           description: OK
@@ -4401,7 +4402,7 @@ paths:
     get:
       summary: List Component Price Points
       tags:
-        - Components
+        - "Component: Price Points"
       responses:
         "201":
           description: Created
@@ -4474,7 +4475,7 @@ paths:
     post:
       summary: Bulk Create Component Price Points
       tags:
-        - Components
+        - "Component: Price Points"
       responses:
         "200":
           description: OK
@@ -4548,21 +4549,25 @@ paths:
   "/components/{component_id}/price_points/{price_point_id}.json":
     parameters:
       - schema:
-          type: integer
+          type:
+            - integer
+            - string
         name: component_id
         in: path
         required: true
-        description: The Chargify id of the component to which the price point belongs
+        description: "The id or handle of the component. When using the handle, it must be prefixed with `handle:`. Example: `123` for an integer ID, or `handle:example-product-handle` for a string handle."
       - schema:
-          type: integer
+          type:
+            - integer
+            - string
         name: price_point_id
         in: path
         required: true
-        description: The Chargify id of the price point
+        description: "The id or handle of the price point. When using the handle, it must be prefixed with `handle:`. Example: `123` for an integer ID, or `handle:example-price_point-handle` for a string handle."
     put:
       summary: Update Component Price Point
       tags:
-        - Components
+        - "Component: Price Points"
       responses:
         "200":
           description: OK
@@ -4637,10 +4642,23 @@ paths:
                         _destroy: true
                       - starting_quantity: 101
                         unit_price: 4
+    get:
+      summary: Read Component Price Point
+      tags:
+        - "Component: Price Points"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "./components/schemas/Component-Price-Point-Response.yaml"
+      operationId: readComponentPricePoint
+      description: Use this endpoint to retrieve details for a specific component price point. You can achieve this by using either the component price point ID or handle.
     delete:
       summary: Archive Component Price Point
       tags:
-        - Components
+        - "Component: Price Points"
       responses:
         "200":
           description: OK
@@ -4705,7 +4723,7 @@ paths:
     put:
       summary: Unarchive Component Price Point
       tags:
-        - Components
+        - "Component: Price Points"
       responses:
         "200":
           description: OK
@@ -4750,7 +4768,7 @@ paths:
     post:
       summary: Create Currency Prices
       tags:
-        - Components
+        - "Component: Price Points"
       responses:
         "200":
           description: OK
@@ -4806,7 +4824,7 @@ paths:
     put:
       summary: Update Currency Prices
       tags:
-        - Components
+        - "Component: Price Points"
       responses:
         "200":
           description: OK
@@ -5769,7 +5787,7 @@ paths:
         name: product_id
         in: path
         required: true
-        description: "The id or handle of the product. When using the handle, it must be prefixed with `handle:`"
+        description: "The id or handle of the product. When using the handle, it must be prefixed with `handle:`. Example: `123` for an integer ID, or `handle:example-product-handle` for a string handle."
       - schema:
           type:
             - integer
@@ -5777,7 +5795,7 @@ paths:
         name: price_point_id
         in: path
         required: true
-        description: "The id or handle of the price point. When using the handle, it must be prefixed with `handle:`"
+        description: "The id or handle of the price point. When using the handle, it must be prefixed with `handle:`. Example: `123` for an integer ID, or `handle:example-product-price-point-handle` for a string handle."
     put:
       summary: Update Product Price Point
       tags:
@@ -5861,7 +5879,7 @@ paths:
                       created_at: 2023-11-27T06:37:20-05:00
                       updated_at: 2023-11-27T06:37:20-05:00
       operationId: readProductPricePoint
-      description: Use this endpoint to retrieve details for a specific product price point.
+      description: Use this endpoint to retrieve details for a specific product price point. You can achieve this by using either the product price point ID or handle.
       parameters:
         - schema:
             type: boolean
@@ -17678,7 +17696,7 @@ paths:
     get:
       summary: List All Components Price Points
       tags:
-        - Components
+        - "Component: Price Points"
       responses:
         "200":
           description: OK

--- a/reference/Chargify-API.v1.yaml
+++ b/reference/Chargify-API.v1.yaml
@@ -274,6 +274,7 @@ tags:
   - name: Billing Portal
   - name: Coupons
   - name: Components
+  - name: "Component: Price Points"
   - name: Customers
   - name: Custom Fields
   - name: Events
@@ -4617,7 +4618,7 @@ paths:
     put:
       summary: Promote Price Point to Default
       tags:
-        - Components
+        - "Component: Price Points"
       responses:
         "200":
           description: OK
@@ -4830,7 +4831,7 @@ paths:
     post:
       summary: Create Component Price Point
       tags:
-        - Components
+        - "Component: Price Points"
       responses:
         "200":
           description: OK
@@ -4895,7 +4896,7 @@ paths:
     get:
       summary: List Component Price Points
       tags:
-        - Components
+        - "Component: Price Points"
       responses:
         "201":
           description: Created
@@ -4968,7 +4969,7 @@ paths:
     post:
       summary: Bulk Create Component Price Points
       tags:
-        - Components
+        - "Component: Price Points"
       responses:
         "200":
           description: OK
@@ -5042,21 +5043,25 @@ paths:
   "/components/{component_id}/price_points/{price_point_id}.json":
     parameters:
       - schema:
-          type: integer
+          type:
+            - integer
+            - string
         name: component_id
         in: path
         required: true
-        description: The Chargify id of the component to which the price point belongs
+        description: "The id or handle of the component. When using the handle, it must be prefixed with `handle:`. Example: `123` for an integer ID, or `handle:example-component-handle` for a string handle."
       - schema:
-          type: integer
+          type:
+            - integer
+            - string
         name: price_point_id
         in: path
         required: true
-        description: The Chargify id of the price point
+        description: "The id or handle of the price point. When using the handle, it must be prefixed with `handle:`. Example: `123` for an integer ID, or `handle:example-price_point-handle` for a string handle."
     put:
       summary: Update Component Price Point
       tags:
-        - Components
+        - "Component: Price Points"
       responses:
         "200":
           description: OK
@@ -5131,10 +5136,23 @@ paths:
                         _destroy: true
                       - starting_quantity: 101
                         unit_price: 4
+    get:
+      summary: Read Component Price Point
+      tags:
+        - "Component: Price Points"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "../components/schemas/Component-Price-Point-Response.yaml"
+      operationId: readComponentPricePoint
+      description: Use this endpoint to retrieve details for a specific component price point. You can achieve this by using either the component price point ID or handle.
     delete:
       summary: Archive Component Price Point
       tags:
-        - Components
+        - "Component: Price Points"
       responses:
         "200":
           description: OK
@@ -5199,7 +5217,7 @@ paths:
     put:
       summary: Unarchive Component Price Point
       tags:
-        - Components
+        - "Component: Price Points"
       responses:
         "200":
           description: OK
@@ -5244,7 +5262,7 @@ paths:
     post:
       summary: Create Currency Prices
       tags:
-        - Components
+        - "Component: Price Points"
       responses:
         "200":
           description: OK
@@ -5300,7 +5318,7 @@ paths:
     put:
       summary: Update Currency Prices
       tags:
-        - Components
+        - "Component: Price Points"
       responses:
         "200":
           description: OK
@@ -18372,7 +18390,7 @@ paths:
     get:
       summary: List All Components Price Points
       tags:
-        - Components
+        - "Component: Price Points"
       responses:
         "200":
           description: OK


### PR DESCRIPTION
**!!Breaking Change:** To align with the `Products` and `Product: Price Points` convention and increase readability, I've moved the price points-related endpoints from `Components` to `Component: Price Points`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new operations for reading and archiving component price points.
  - Added support for both integer and string types for `component_id` and `price_point_id` parameters.
  
- **Enhancements**
  - Updated tags and descriptions for paths related to price points for better clarity and consistency.
  - Enhanced descriptions for product and price point IDs, including examples and handling for IDs and handles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->